### PR TITLE
Bugfix/oepcis 487 fix cbv vocabulary

### DIFF
--- a/src/main/java/io/openepcis/epc/translator/Converter.java
+++ b/src/main/java/io/openepcis/epc/translator/Converter.java
@@ -29,6 +29,7 @@ public class Converter {
   private final Set<io.openepcis.epc.translator.converter.Converter> dl = new HashSet<>();
   private final Set<io.openepcis.epc.translator.converter.Converter> classLevelTranslator =
       new HashSet<>();
+  private final EventVocabularyFormatter eventVocabularyFormatter = new EventVocabularyFormatter();
 
   public Converter() {
     // Add all EPC instance-level converter
@@ -202,7 +203,7 @@ public class Converter {
   public String toWebURIVocabulary(final String urnVocabulary) {
     return urnVocabulary == null || urnVocabulary.trim().equals("")
         ? urnVocabulary
-        : EventVocabularyFormatter.canonicalWebURIVocabulary(urnVocabulary);
+        : eventVocabularyFormatter.canonicalWebURIVocabulary(urnVocabulary);
   }
 
   /**
@@ -216,7 +217,7 @@ public class Converter {
   public String toUrnVocabulary(final String webUriVocabulary) {
     return webUriVocabulary == null || webUriVocabulary.trim().equals("")
         ? webUriVocabulary
-        : EventVocabularyFormatter.canonicalString(webUriVocabulary);
+        : eventVocabularyFormatter.canonicalString(webUriVocabulary);
   }
 
   /**
@@ -229,7 +230,7 @@ public class Converter {
   public String toBareStringVocabulary(final String eventVocabulary) {
     return eventVocabulary == null || eventVocabulary.trim().equals("")
         ? eventVocabulary
-        : EventVocabularyFormatter.bareString(eventVocabulary);
+        : eventVocabularyFormatter.bareString(eventVocabulary);
   }
 
   /**
@@ -245,6 +246,6 @@ public class Converter {
       final String bareString, final String fieldName, final String format) {
     return bareString == null || bareString.trim().equals("") || fieldName == null
         ? bareString
-        : EventVocabularyFormatter.cbvVocabulary(bareString, fieldName, format);
+        : eventVocabularyFormatter.cbvVocabulary(bareString, fieldName, format);
   }
 }

--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -53,7 +53,7 @@ public class EventVocabularyFormatter {
 
   // Method to convert the CBV URN formatted vocabularies into WebURI vocabulary. Used during event
   // hash generator.
-  public static String canonicalWebURIVocabulary(final String urnVocabulary) {
+  public String canonicalWebURIVocabulary(final String urnVocabulary) {
 
     if (urnVocabulary.startsWith(BIZ_STEP_URN_PREFIX)) {
       // For Business Step remove the urn:epcglobal:cbv:bizstep: and replace with
@@ -88,7 +88,7 @@ public class EventVocabularyFormatter {
 
   // Method to convert the CBV WebURI formatted vocabularies into URN vocabulary. Used during
   // JSON/JSON-LD conversion to XML.
-  public static String canonicalString(final String webUriVocabulary) {
+  public String canonicalString(final String webUriVocabulary) {
 
     if (webUriVocabulary.startsWith(BIZ_STEP_WEB_URI_PREFIX)) {
       // For Business Step remove the https://ns.gs1.org/voc/Bizstep- and replace with
@@ -125,7 +125,7 @@ public class EventVocabularyFormatter {
 
   // Method to convert the CBV URN/WebURI formatted vocabularies into BareString vocabulary. Used
   // during XML -> JSON/JSON-LD conversion.
-  public static String bareString(final String cbvVocabulary) {
+  public String bareString(final String cbvVocabulary) {
     if (URN_FORMATTED_CBV_STRING.stream().anyMatch(cbvVocabulary::startsWith)) {
       // Check if the CBV URN Vocabulary matches any of the pre-defined CBV URN string if so remove
       // the URN prefix and return bare string.
@@ -141,7 +141,7 @@ public class EventVocabularyFormatter {
 
   // Method to convert the BareString vocabularies into CBV formatted URN/WebURI vocabulary. Used
   // during JSON/JSON-LD -> XML conversion.
-  public static String cbvVocabulary(
+  public String cbvVocabulary(
       final String bareString, final String fieldName, final String format) {
     // Check for the fieldName and based on that return the respective CBV formatted vocabulary in
     // either WebURI or URN format.

--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -31,7 +31,7 @@ public class EventVocabularyFormatter {
   private static final String BIZ_TRANSACTION_URN_PREFIX = URN_PREFIX + "btt:";
   private static final String SRC_DEST_URN_PREFIX = URN_PREFIX + "sdt:";
   private static final String ERR_REASON_URN_PREFIX = URN_PREFIX + "er:";
-  private static final String BIZ_STEP_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/Bizstep-";
+  private static final String BIZ_STEP_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/BizStep-";
   private static final String DISPOSITION_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/Disp-";
   private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/BTT-";
   private static final String SRC_DEST_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/SDT-";

--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -31,11 +31,11 @@ public class EventVocabularyFormatter {
   private static final String BIZ_TRANSACTION_URN_PREFIX = URN_PREFIX + "btt:";
   private static final String SRC_DEST_URN_PREFIX = URN_PREFIX + "sdt:";
   private static final String ERR_REASON_URN_PREFIX = URN_PREFIX + "er:";
-  private static final String BIZ_STEP_WEB_URI_PREFIX = WEB_URI_PREFIX + "voc/Bizstep-";
-  private static final String DISPOSITION_WEB_URI_PREFIX = WEB_URI_PREFIX + "voc/Disp-";
-  private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = WEB_URI_PREFIX + "voc/BTT-";
-  private static final String SRC_DEST_WEB_URI_PREFIX = WEB_URI_PREFIX + "voc/SDT-";
-  private static final String ERR_REASON_WEB_URI_PREFIX = WEB_URI_PREFIX + "voc/ER-";
+  private static final String BIZ_STEP_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/Bizstep-";
+  private static final String DISPOSITION_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/Disp-";
+  private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/BTT-";
+  private static final String SRC_DEST_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/SDT-";
+  private static final String ERR_REASON_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/ER-";
   private static final List<String> URN_FORMATTED_CBV_STRING =
       Arrays.asList(
           BIZ_STEP_URN_PREFIX,

--- a/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
@@ -33,10 +33,10 @@ public class BareStringVocabularyTest {
 
   @Test
   public void BizStepBareStringTest() {
-    String bizStep = "https://ref.gs1.org/cbv/Bizstep-departing";
+    String bizStep = "https://ref.gs1.org/cbv/BizStep-departing";
     assertEquals("departing", converter.toBareStringVocabulary(bizStep));
 
-    bizStep = "https://ref.gs1.org/cbv/Bizstep-commissioning";
+    bizStep = "https://ref.gs1.org/cbv/BizStep-commissioning";
     assertEquals("commissioning", converter.toBareStringVocabulary(bizStep));
 
     bizStep = "https://example.com/cbv/My-Own-Vocabulary";

--- a/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
@@ -33,15 +33,15 @@ public class BareStringVocabularyTest {
 
   @Test
   public void BizStepBareStringTest() {
-    String bizStep = "https://ref.gs1.org/voc/Bizstep-departing";
+    String bizStep = "https://ref.gs1.org/cbv/Bizstep-departing";
     assertEquals("departing", converter.toBareStringVocabulary(bizStep));
 
-    bizStep = "https://ref.gs1.org/voc/Bizstep-commissioning";
+    bizStep = "https://ref.gs1.org/cbv/Bizstep-commissioning";
     assertEquals("commissioning", converter.toBareStringVocabulary(bizStep));
 
-    bizStep = "https://example.com/voc/My-Own-Vocabulary";
+    bizStep = "https://example.com/cbv/My-Own-Vocabulary";
     assertEquals(
-        "https://example.com/voc/My-Own-Vocabulary", converter.toBareStringVocabulary(bizStep));
+        "https://example.com/cbv/My-Own-Vocabulary", converter.toBareStringVocabulary(bizStep));
 
     bizStep = "urn:epcglobal:cbv:bizstep:inspecting";
     assertEquals("inspecting", converter.toBareStringVocabulary(bizStep));
@@ -61,10 +61,10 @@ public class BareStringVocabularyTest {
 
   @Test
   public void DispositionBareStringTest() {
-    String disposition = "https://ref.gs1.org/voc/Disp-in_transit";
+    String disposition = "https://ref.gs1.org/cbv/Disp-in_transit";
     assertEquals("in_transit", converter.toBareStringVocabulary(disposition));
 
-    disposition = "https://ref.gs1.org/voc/Disp-recalled";
+    disposition = "https://ref.gs1.org/cbv/Disp-recalled";
     assertEquals("recalled", converter.toBareStringVocabulary(disposition));
 
     disposition = "https://example.com/My-Own-Disposition";
@@ -85,13 +85,13 @@ public class BareStringVocabularyTest {
 
   @Test
   public void BizTransactionBareStringTest() {
-    String bizTransactionType = "https://ref.gs1.org/voc/BTT-inv";
+    String bizTransactionType = "https://ref.gs1.org/cbv/BTT-inv";
     assertEquals("inv", converter.toBareStringVocabulary(bizTransactionType));
 
-    bizTransactionType = "https://ref.gs1.org/voc/BTT-desadv";
+    bizTransactionType = "https://ref.gs1.org/cbv/BTT-desadv";
     assertEquals("desadv", converter.toBareStringVocabulary(bizTransactionType));
 
-    bizTransactionType = "https://ref.gs1.org/voc/BTT-po";
+    bizTransactionType = "https://ref.gs1.org/cbv/BTT-po";
     assertEquals("po", converter.toBareStringVocabulary(bizTransactionType));
 
     bizTransactionType = "https://example.com/department/My_Own_Biz_Type";
@@ -116,13 +116,13 @@ public class BareStringVocabularyTest {
 
   @Test
   public void SourceDestinationBareStringTest() {
-    String srcDestinationString = "https://ref.gs1.org/voc/SDT-possessing_party";
+    String srcDestinationString = "https://ref.gs1.org/cbv/SDT-possessing_party";
     assertEquals("possessing_party", converter.toBareStringVocabulary(srcDestinationString));
 
-    srcDestinationString = "https://ref.gs1.org/voc/SDT-owning_party";
+    srcDestinationString = "https://ref.gs1.org/cbv/SDT-owning_party";
     assertEquals("owning_party", converter.toBareStringVocabulary(srcDestinationString));
 
-    srcDestinationString = "https://ref.gs1.org/voc/SDT-location";
+    srcDestinationString = "https://ref.gs1.org/cbv/SDT-location";
     assertEquals("location", converter.toBareStringVocabulary(srcDestinationString));
 
     srcDestinationString = "https://example.com/source/My_Own_Source";
@@ -153,13 +153,13 @@ public class BareStringVocabularyTest {
 
   @Test
   public void ErrorDeclarationReasonBareStringTest() {
-    String errorReason = "https://ref.gs1.org/voc/ER-incorrect_data";
+    String errorReason = "https://ref.gs1.org/cbv/ER-incorrect_data";
     assertEquals("incorrect_data", converter.toBareStringVocabulary(errorReason));
 
-    errorReason = "https://ref.gs1.org/voc/ER-did_not_occur";
+    errorReason = "https://ref.gs1.org/cbv/ER-did_not_occur";
     assertEquals("did_not_occur", converter.toBareStringVocabulary(errorReason));
 
-    errorReason = "https://ref.gs1.org/voc/ER-other";
+    errorReason = "https://ref.gs1.org/cbv/ER-other";
     assertEquals("other", converter.toBareStringVocabulary(errorReason));
 
     errorReason = "https://example.com/myReason/ReasonDescription";

--- a/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
@@ -43,10 +43,10 @@ public class CbvVocabularyTest {
 
     // Converting BizStep BareString to CBV vocabulary in WebURI format.
     assertEquals(
-        "https://ref.gs1.org/cbv/Bizstep-shipping",
+        "https://ref.gs1.org/cbv/BizStep-shipping",
         converter.toCbvVocabulary("shipping", "bizStep", "webUri"));
     assertEquals(
-        "https://ref.gs1.org/cbv/Bizstep-packing",
+        "https://ref.gs1.org/cbv/BizStep-packing",
         converter.toCbvVocabulary("packing", "bizStep", "webUri"));
 
     assertEquals("", converter.toCbvVocabulary("", "bizStep", ""));

--- a/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
@@ -43,10 +43,10 @@ public class CbvVocabularyTest {
 
     // Converting BizStep BareString to CBV vocabulary in WebURI format.
     assertEquals(
-        "https://ref.gs1.org/voc/Bizstep-shipping",
+        "https://ref.gs1.org/cbv/Bizstep-shipping",
         converter.toCbvVocabulary("shipping", "bizStep", "webUri"));
     assertEquals(
-        "https://ref.gs1.org/voc/Bizstep-packing",
+        "https://ref.gs1.org/cbv/Bizstep-packing",
         converter.toCbvVocabulary("packing", "bizStep", "webUri"));
 
     assertEquals("", converter.toCbvVocabulary("", "bizStep", ""));
@@ -67,10 +67,10 @@ public class CbvVocabularyTest {
 
     // Converting Disposition BareString to CBV vocabulary in WebURI format.
     assertEquals(
-        "https://ref.gs1.org/voc/Disp-in_transit",
+        "https://ref.gs1.org/cbv/Disp-in_transit",
         converter.toCbvVocabulary("in_transit", "disposition", "WebURI"));
     assertEquals(
-        "https://ref.gs1.org/voc/Disp-partially_dispensed",
+        "https://ref.gs1.org/cbv/Disp-partially_dispensed",
         converter.toCbvVocabulary("partially_dispensed", "disposition", "WebURI"));
 
     // Converting PersistentDisposition BareString to CBV vocabulary in URN format.
@@ -83,10 +83,10 @@ public class CbvVocabularyTest {
 
     // Converting PersistentDisposition BareString to CBV vocabulary in URN format.
     assertEquals(
-        "https://ref.gs1.org/voc/Disp-in_transit",
+        "https://ref.gs1.org/cbv/Disp-in_transit",
         converter.toCbvVocabulary("in_transit", "persistentDisposition", "WebURI"));
     assertEquals(
-        "https://ref.gs1.org/voc/Disp-partially_dispensed",
+        "https://ref.gs1.org/cbv/Disp-partially_dispensed",
         converter.toCbvVocabulary("partially_dispensed", "persistentDisposition", "WebURI"));
   }
 
@@ -103,13 +103,13 @@ public class CbvVocabularyTest {
 
     // Converting BizTransaction/BizTransactionList BareString to CBV vocabulary in WebURI format.
     assertEquals(
-        "https://ref.gs1.org/voc/BTT-po",
+        "https://ref.gs1.org/cbv/BTT-po",
         converter.toCbvVocabulary("po", "bizTransaction", "webURi"));
     assertEquals(
-        "https://ref.gs1.org/voc/BTT-inv",
+        "https://ref.gs1.org/cbv/BTT-inv",
         converter.toCbvVocabulary("inv", "bizTransaction", "webURi"));
     assertEquals(
-        "https://ref.gs1.org/voc/BTT-pedigree",
+        "https://ref.gs1.org/cbv/BTT-pedigree",
         converter.toCbvVocabulary("pedigree", "bizTransaction", "webURi"));
   }
 
@@ -128,13 +128,13 @@ public class CbvVocabularyTest {
 
     // Converting Source/SourceList BareString to CBV vocabulary in WebURI format.
     assertEquals(
-        "https://ref.gs1.org/voc/SDT-owning_party",
+        "https://ref.gs1.org/cbv/SDT-owning_party",
         converter.toCbvVocabulary("owning_party", "source", "weburi"));
     assertEquals(
-        "https://ref.gs1.org/voc/SDT-location",
+        "https://ref.gs1.org/cbv/SDT-location",
         converter.toCbvVocabulary("location", "source", "weburi"));
     assertEquals(
-        "https://ref.gs1.org/voc/SDT-processing_party",
+        "https://ref.gs1.org/cbv/SDT-processing_party",
         converter.toCbvVocabulary("processing_party", "source", "weburi"));
 
     // Converting Destination/DestinationList BareString to CBV vocabulary in URN format.
@@ -150,13 +150,13 @@ public class CbvVocabularyTest {
 
     // Converting Destination/DestinationList BareString to CBV vocabulary in WebURI format.
     assertEquals(
-        "https://ref.gs1.org/voc/SDT-owning_party",
+        "https://ref.gs1.org/cbv/SDT-owning_party",
         converter.toCbvVocabulary("owning_party", "Destination", "weburi"));
     assertEquals(
-        "https://ref.gs1.org/voc/SDT-location",
+        "https://ref.gs1.org/cbv/SDT-location",
         converter.toCbvVocabulary("location", "Destination", "weburi"));
     assertEquals(
-        "https://ref.gs1.org/voc/SDT-processing_party",
+        "https://ref.gs1.org/cbv/SDT-processing_party",
         converter.toCbvVocabulary("processing_party", "Destination", "weburi"));
   }
 
@@ -175,12 +175,12 @@ public class CbvVocabularyTest {
 
     // Convert ErrorDeclaration Reason BareString to CBV vocabulary in WebURI format.
     assertEquals(
-        "https://ref.gs1.org/voc/ER-did_not_occur",
+        "https://ref.gs1.org/cbv/ER-did_not_occur",
         converter.toCbvVocabulary("did_not_occur", "reason", "WebURI"));
     assertEquals(
-        "https://ref.gs1.org/voc/ER-incorrect_data",
+        "https://ref.gs1.org/cbv/ER-incorrect_data",
         converter.toCbvVocabulary("incorrect_data", "reason", "WebURI"));
     assertEquals(
-        "https://ref.gs1.org/voc/ER-other", converter.toCbvVocabulary("other", "reason", "WebURI"));
+        "https://ref.gs1.org/cbv/ER-other", converter.toCbvVocabulary("other", "reason", "WebURI"));
   }
 }

--- a/src/test/java/io/openepcis/epc/translator/tests/UrnVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/UrnVocabularyTest.java
@@ -33,16 +33,16 @@ public class UrnVocabularyTest {
 
   @Test
   public void BizStepUrnTest() {
-    String bizStep = "https://ref.gs1.org/cbv/Bizstep-departing";
+    String bizStep = "https://ref.gs1.org/cbv/BizStep-departing";
     assertEquals("urn:epcglobal:cbv:bizstep:departing", converter.toUrnVocabulary(bizStep));
 
-    bizStep = "https://ref.gs1.org/cbv/Bizstep-inspecting";
+    bizStep = "https://ref.gs1.org/cbv/BizStep-inspecting";
     assertEquals("urn:epcglobal:cbv:bizstep:inspecting", converter.toUrnVocabulary(bizStep));
 
-    bizStep = "https://ref.gs1.org/cbv/Bizstep-receiving";
+    bizStep = "https://ref.gs1.org/cbv/BizStep-receiving";
     assertEquals("urn:epcglobal:cbv:bizstep:receiving", converter.toUrnVocabulary(bizStep));
 
-    bizStep = "https://ref.gs1.org/cbv/Bizstep-commissioning";
+    bizStep = "https://ref.gs1.org/cbv/BizStep-commissioning";
     assertEquals("urn:epcglobal:cbv:bizstep:commissioning", converter.toUrnVocabulary(bizStep));
 
     bizStep = "https://example.com/department/My_Own_BizStep";

--- a/src/test/java/io/openepcis/epc/translator/tests/UrnVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/UrnVocabularyTest.java
@@ -33,16 +33,16 @@ public class UrnVocabularyTest {
 
   @Test
   public void BizStepUrnTest() {
-    String bizStep = "https://ref.gs1.org/voc/Bizstep-departing";
+    String bizStep = "https://ref.gs1.org/cbv/Bizstep-departing";
     assertEquals("urn:epcglobal:cbv:bizstep:departing", converter.toUrnVocabulary(bizStep));
 
-    bizStep = "https://ref.gs1.org/voc/Bizstep-inspecting";
+    bizStep = "https://ref.gs1.org/cbv/Bizstep-inspecting";
     assertEquals("urn:epcglobal:cbv:bizstep:inspecting", converter.toUrnVocabulary(bizStep));
 
-    bizStep = "https://ref.gs1.org/voc/Bizstep-receiving";
+    bizStep = "https://ref.gs1.org/cbv/Bizstep-receiving";
     assertEquals("urn:epcglobal:cbv:bizstep:receiving", converter.toUrnVocabulary(bizStep));
 
-    bizStep = "https://ref.gs1.org/voc/Bizstep-commissioning";
+    bizStep = "https://ref.gs1.org/cbv/Bizstep-commissioning";
     assertEquals("urn:epcglobal:cbv:bizstep:commissioning", converter.toUrnVocabulary(bizStep));
 
     bizStep = "https://example.com/department/My_Own_BizStep";
@@ -56,16 +56,16 @@ public class UrnVocabularyTest {
 
   @Test
   public void DispositionUrnTest() {
-    String disposition = "https://ref.gs1.org/voc/Disp-in_transit";
+    String disposition = "https://ref.gs1.org/cbv/Disp-in_transit";
     assertEquals("urn:epcglobal:cbv:disp:in_transit", converter.toUrnVocabulary(disposition));
 
-    disposition = "https://ref.gs1.org/voc/Disp-recalled";
+    disposition = "https://ref.gs1.org/cbv/Disp-recalled";
     assertEquals("urn:epcglobal:cbv:disp:recalled", converter.toUrnVocabulary(disposition));
 
-    disposition = "https://ref.gs1.org/voc/Disp-in_progress";
+    disposition = "https://ref.gs1.org/cbv/Disp-in_progress";
     assertEquals("urn:epcglobal:cbv:disp:in_progress", converter.toUrnVocabulary(disposition));
 
-    disposition = "https://ref.gs1.org/voc/Disp-needs_replacement";
+    disposition = "https://ref.gs1.org/cbv/Disp-needs_replacement";
     assertEquals(
         "urn:epcglobal:cbv:disp:needs_replacement", converter.toUrnVocabulary(disposition));
 
@@ -77,13 +77,13 @@ public class UrnVocabularyTest {
 
   @Test
   public void BizTransactionUrnTest() {
-    String bizTransactionType = "https://ref.gs1.org/voc/BTT-inv";
+    String bizTransactionType = "https://ref.gs1.org/cbv/BTT-inv";
     assertEquals("urn:epcglobal:cbv:btt:inv", converter.toUrnVocabulary(bizTransactionType));
 
-    bizTransactionType = "https://ref.gs1.org/voc/BTT-desadv";
+    bizTransactionType = "https://ref.gs1.org/cbv/BTT-desadv";
     assertEquals("urn:epcglobal:cbv:btt:desadv", converter.toUrnVocabulary(bizTransactionType));
 
-    bizTransactionType = "https://ref.gs1.org/voc/BTT-po";
+    bizTransactionType = "https://ref.gs1.org/cbv/BTT-po";
     assertEquals("urn:epcglobal:cbv:btt:po", converter.toUrnVocabulary(bizTransactionType));
 
     bizTransactionType = "https://example.com/department/My_Own_Biz_Type";
@@ -94,14 +94,14 @@ public class UrnVocabularyTest {
 
   @Test
   public void SourceDestinationUrnTest() {
-    String canonicalString = "https://ref.gs1.org/voc/SDT-possessing_party";
+    String canonicalString = "https://ref.gs1.org/cbv/SDT-possessing_party";
     assertEquals(
         "urn:epcglobal:cbv:sdt:possessing_party", converter.toUrnVocabulary(canonicalString));
 
-    canonicalString = "https://ref.gs1.org/voc/SDT-owning_party";
+    canonicalString = "https://ref.gs1.org/cbv/SDT-owning_party";
     assertEquals("urn:epcglobal:cbv:sdt:owning_party", converter.toUrnVocabulary(canonicalString));
 
-    canonicalString = "https://ref.gs1.org/voc/SDT-location";
+    canonicalString = "https://ref.gs1.org/cbv/SDT-location";
     assertEquals("urn:epcglobal:cbv:sdt:location", converter.toUrnVocabulary(canonicalString));
 
     canonicalString = "https://example.com/source/My_Own_Source";
@@ -117,13 +117,13 @@ public class UrnVocabularyTest {
 
   @Test
   public void ErrorDeclarationReasonUrnTest() {
-    String errorReason = "https://ref.gs1.org/voc/ER-incorrect_data";
+    String errorReason = "https://ref.gs1.org/cbv/ER-incorrect_data";
     assertEquals("urn:epcglobal:cbv:er:incorrect_data", converter.toUrnVocabulary(errorReason));
 
-    errorReason = "https://ref.gs1.org/voc/ER-did_not_occur";
+    errorReason = "https://ref.gs1.org/cbv/ER-did_not_occur";
     assertEquals("urn:epcglobal:cbv:er:did_not_occur", converter.toUrnVocabulary(errorReason));
 
-    errorReason = "https://ref.gs1.org/voc/ER-other";
+    errorReason = "https://ref.gs1.org/cbv/ER-other";
     assertEquals("urn:epcglobal:cbv:er:other", converter.toUrnVocabulary(errorReason));
 
     errorReason = "https://example.com/error/My_Own_Reason";

--- a/src/test/java/io/openepcis/epc/translator/tests/WebURIVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/WebURIVocabularyTest.java
@@ -35,19 +35,19 @@ public class WebURIVocabularyTest {
   public void BizStepWebUriTest() {
     String bizStep = "urn:epcglobal:cbv:bizstep:departing";
     assertEquals(
-        "https://ref.gs1.org/voc/Bizstep-departing", converter.toWebURIVocabulary(bizStep));
+        "https://ref.gs1.org/cbv/Bizstep-departing", converter.toWebURIVocabulary(bizStep));
 
     bizStep = "urn:epcglobal:cbv:bizstep:inspecting";
     assertEquals(
-        "https://ref.gs1.org/voc/Bizstep-inspecting", converter.toWebURIVocabulary(bizStep));
+        "https://ref.gs1.org/cbv/Bizstep-inspecting", converter.toWebURIVocabulary(bizStep));
 
     bizStep = "urn:epcglobal:cbv:bizstep:receiving";
     assertEquals(
-        "https://ref.gs1.org/voc/Bizstep-receiving", converter.toWebURIVocabulary(bizStep));
+        "https://ref.gs1.org/cbv/Bizstep-receiving", converter.toWebURIVocabulary(bizStep));
 
     bizStep = "urn:epcglobal:cbv:bizstep:commissioning";
     assertEquals(
-        "https://ref.gs1.org/voc/Bizstep-commissioning", converter.toWebURIVocabulary(bizStep));
+        "https://ref.gs1.org/cbv/Bizstep-commissioning", converter.toWebURIVocabulary(bizStep));
 
     bizStep = "urn:example:department:bizstep:custom_business";
     assertEquals(
@@ -62,19 +62,19 @@ public class WebURIVocabularyTest {
   public void DispositionWebUriTest() {
     String disposition = "urn:epcglobal:cbv:disp:in_transit";
     assertEquals(
-        "https://ref.gs1.org/voc/Disp-in_transit", converter.toWebURIVocabulary(disposition));
+        "https://ref.gs1.org/cbv/Disp-in_transit", converter.toWebURIVocabulary(disposition));
 
     disposition = "urn:epcglobal:cbv:disp:recalled";
     assertEquals(
-        "https://ref.gs1.org/voc/Disp-recalled", converter.toWebURIVocabulary(disposition));
+        "https://ref.gs1.org/cbv/Disp-recalled", converter.toWebURIVocabulary(disposition));
 
     disposition = "urn:epcglobal:cbv:disp:in_progress";
     assertEquals(
-        "https://ref.gs1.org/voc/Disp-in_progress", converter.toWebURIVocabulary(disposition));
+        "https://ref.gs1.org/cbv/Disp-in_progress", converter.toWebURIVocabulary(disposition));
 
     disposition = "urn:epcglobal:cbv:disp:needs_replacement";
     assertEquals(
-        "https://ref.gs1.org/voc/Disp-needs_replacement",
+        "https://ref.gs1.org/cbv/Disp-needs_replacement",
         converter.toWebURIVocabulary(disposition));
 
     disposition = "urn:example:department:disposition:custom_disposition";
@@ -87,15 +87,15 @@ public class WebURIVocabularyTest {
   public void BizTransactionWebUriTest() {
     String bizTransactionType = "urn:epcglobal:cbv:btt:inv";
     assertEquals(
-        "https://ref.gs1.org/voc/BTT-inv", converter.toWebURIVocabulary(bizTransactionType));
+        "https://ref.gs1.org/cbv/BTT-inv", converter.toWebURIVocabulary(bizTransactionType));
 
     bizTransactionType = "urn:epcglobal:cbv:btt:desadv";
     assertEquals(
-        "https://ref.gs1.org/voc/BTT-desadv", converter.toWebURIVocabulary(bizTransactionType));
+        "https://ref.gs1.org/cbv/BTT-desadv", converter.toWebURIVocabulary(bizTransactionType));
 
     bizTransactionType = "urn:epcglobal:cbv:btt:po";
     assertEquals(
-        "https://ref.gs1.org/voc/BTT-po", converter.toWebURIVocabulary(bizTransactionType));
+        "https://ref.gs1.org/cbv/BTT-po", converter.toWebURIVocabulary(bizTransactionType));
 
     bizTransactionType = "urn:example:department:error:custom_error";
     assertEquals(
@@ -107,14 +107,14 @@ public class WebURIVocabularyTest {
   public void SourceDestinationWebUriTest() {
     String sourceType = "urn:epcglobal:cbv:sdt:possessing_party";
     assertEquals(
-        "https://ref.gs1.org/voc/SDT-possessing_party", converter.toWebURIVocabulary(sourceType));
+        "https://ref.gs1.org/cbv/SDT-possessing_party", converter.toWebURIVocabulary(sourceType));
 
     sourceType = "urn:epcglobal:cbv:sdt:owning_party";
     assertEquals(
-        "https://ref.gs1.org/voc/SDT-owning_party", converter.toWebURIVocabulary(sourceType));
+        "https://ref.gs1.org/cbv/SDT-owning_party", converter.toWebURIVocabulary(sourceType));
 
     sourceType = "urn:epcglobal:cbv:sdt:location";
-    assertEquals("https://ref.gs1.org/voc/SDT-location", converter.toWebURIVocabulary(sourceType));
+    assertEquals("https://ref.gs1.org/cbv/SDT-location", converter.toWebURIVocabulary(sourceType));
 
     sourceType = "urn:example:department:source:custom_source";
     assertEquals(
@@ -128,14 +128,14 @@ public class WebURIVocabularyTest {
   public void ErrorDeclarationReasonWebUriTest() {
     String errorReason = "urn:epcglobal:cbv:er:incorrect_data";
     assertEquals(
-        "https://ref.gs1.org/voc/ER-incorrect_data", converter.toWebURIVocabulary(errorReason));
+        "https://ref.gs1.org/cbv/ER-incorrect_data", converter.toWebURIVocabulary(errorReason));
 
     errorReason = "urn:epcglobal:cbv:er:did_not_occur";
     assertEquals(
-        "https://ref.gs1.org/voc/ER-did_not_occur", converter.toWebURIVocabulary(errorReason));
+        "https://ref.gs1.org/cbv/ER-did_not_occur", converter.toWebURIVocabulary(errorReason));
 
     errorReason = "urn:epcglobal:cbv:er:other";
-    assertEquals("https://ref.gs1.org/voc/ER-other", converter.toWebURIVocabulary(errorReason));
+    assertEquals("https://ref.gs1.org/cbv/ER-other", converter.toWebURIVocabulary(errorReason));
 
     errorReason = "urn:example:department:error:custom_error";
     assertEquals(

--- a/src/test/java/io/openepcis/epc/translator/tests/WebURIVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/WebURIVocabularyTest.java
@@ -35,19 +35,19 @@ public class WebURIVocabularyTest {
   public void BizStepWebUriTest() {
     String bizStep = "urn:epcglobal:cbv:bizstep:departing";
     assertEquals(
-        "https://ref.gs1.org/cbv/Bizstep-departing", converter.toWebURIVocabulary(bizStep));
+        "https://ref.gs1.org/cbv/BizStep-departing", converter.toWebURIVocabulary(bizStep));
 
     bizStep = "urn:epcglobal:cbv:bizstep:inspecting";
     assertEquals(
-        "https://ref.gs1.org/cbv/Bizstep-inspecting", converter.toWebURIVocabulary(bizStep));
+        "https://ref.gs1.org/cbv/BizStep-inspecting", converter.toWebURIVocabulary(bizStep));
 
     bizStep = "urn:epcglobal:cbv:bizstep:receiving";
     assertEquals(
-        "https://ref.gs1.org/cbv/Bizstep-receiving", converter.toWebURIVocabulary(bizStep));
+        "https://ref.gs1.org/cbv/BizStep-receiving", converter.toWebURIVocabulary(bizStep));
 
     bizStep = "urn:epcglobal:cbv:bizstep:commissioning";
     assertEquals(
-        "https://ref.gs1.org/cbv/Bizstep-commissioning", converter.toWebURIVocabulary(bizStep));
+        "https://ref.gs1.org/cbv/BizStep-commissioning", converter.toWebURIVocabulary(bizStep));
 
     bizStep = "urn:example:department:bizstep:custom_business";
     assertEquals(


### PR DESCRIPTION
This PR will fix the issues associated with converting of URN vocabulary in CBV format to WebURI format:

1. Fix the issue with wording and use the `cbv` instead of older `voc`.
2. Fix the issue with wording `bizStep` instead of `bizstep`.
3. Make the vocabulary converting class instance level instead of static. similar to identifier converting class.

@sboeckelmann 
Kindly request you to review and approve this pull request.