### PR TITLE
Bugifx/oepcis 488 fix bare string conversion for curie strings

### DIFF
--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -22,7 +22,8 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.NONE)
 public class EventVocabularyFormatter {
-  private static final String WEB_URI_PREFIX = "https://ref.gs1.org/";
+  private static final String WEB_URI_PREFIX = "https://ref.gs1.org/cbv/";
+  private static final String GS1_WEB_URI = "https://gs1.org/voc/";
   private static final String URN_PREFIX = "urn:epcglobal:cbv:";
   private static final String WEBURI_FORMATTED = "WebURI";
   private static final String BIZ_STEP_URN_PREFIX = URN_PREFIX + "bizstep:";
@@ -35,11 +36,16 @@ public class EventVocabularyFormatter {
   private static final String SRC_DEST_CURIE_PREFIX = "cbv:SDT-";
   private static final String ERR_REASON_URN_PREFIX = URN_PREFIX + "er:";
   private static final String ERR_REASON_CURIE_PREFIX = "cbv:ER-";
-  private static final String BIZ_STEP_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/BizStep-";
-  private static final String DISPOSITION_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/Disp-";
-  private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/BTT-";
-  private static final String SRC_DEST_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/SDT-";
-  private static final String ERR_REASON_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/ER-";
+  private static final String BIZ_STEP_WEB_URI_PREFIX = WEB_URI_PREFIX + "BizStep-";
+  private static final String DISPOSITION_WEB_URI_PREFIX = WEB_URI_PREFIX + "Disp-";
+  private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = WEB_URI_PREFIX + "BTT-";
+  private static final String SRC_DEST_WEB_URI_PREFIX = WEB_URI_PREFIX + "SDT-";
+  private static final String ERR_REASON_WEB_URI_PREFIX = WEB_URI_PREFIX + "ER-";
+  private static final String BIZ_STEP_GS1_PREFIX = GS1_WEB_URI + "BizStep-";
+  private static final String DISPOSITION_GS1_PREFIX = GS1_WEB_URI + "Disp-";
+  private static final String BIZ_TRANSACTION_GS1_PREFIX = GS1_WEB_URI + "BTT-";
+  private static final String SRC_DEST_GS1_PREFIX = GS1_WEB_URI + "SDT-";
+  private static final String ERR_REASON_GS1_PREFIX = GS1_WEB_URI + "ER-";
   private static final List<String> URN_FORMATTED_CBV_STRING =
       Arrays.asList(
           BIZ_STEP_URN_PREFIX,
@@ -47,7 +53,6 @@ public class EventVocabularyFormatter {
           BIZ_TRANSACTION_URN_PREFIX,
           SRC_DEST_URN_PREFIX,
           ERR_REASON_URN_PREFIX);
-
   private static final List<String> CURIE_FORMATTED_CBV_STRING =
       Arrays.asList(
           BIZ_STEP_CURIE_PREFIX,
@@ -61,7 +66,12 @@ public class EventVocabularyFormatter {
           DISPOSITION_WEB_URI_PREFIX,
           BIZ_TRANSACTION_WEB_URI_PREFIX,
           SRC_DEST_WEB_URI_PREFIX,
-          ERR_REASON_WEB_URI_PREFIX);
+          ERR_REASON_WEB_URI_PREFIX,
+          BIZ_STEP_GS1_PREFIX,
+          DISPOSITION_GS1_PREFIX,
+          BIZ_TRANSACTION_GS1_PREFIX,
+          SRC_DEST_GS1_PREFIX,
+          ERR_REASON_GS1_PREFIX);
 
   // Method to convert the CBV URN formatted vocabularies into WebURI vocabulary. Used during event
   // hash generator.
@@ -142,12 +152,12 @@ public class EventVocabularyFormatter {
       // Check if the CBV URN Vocabulary matches any of the pre-defined CBV URN string if so remove
       // the URN prefix and return bare string.
       return cbvVocabulary.substring(cbvVocabulary.lastIndexOf(":") + 1);
-    } else if (CURIE_FORMATTED_CBV_STRING.stream().anyMatch(cbvVocabulary::startsWith)) {
-      // If the cbv matches the curie urn then remove the prefix and return bare string
-      return cbvVocabulary.substring(cbvVocabulary.lastIndexOf("-") + 1);
     } else if (WEBURI_FORMATTED_CBV_STRING.stream().anyMatch(cbvVocabulary::startsWith)) {
       // Check if the CBV WebURI vocabulary matches any of the pre-defined CBV WebURI string if so
       // remove the WebURI prefix and return bare string.
+      return cbvVocabulary.substring(cbvVocabulary.lastIndexOf("-") + 1);
+    } else if (CURIE_FORMATTED_CBV_STRING.stream().anyMatch(cbvVocabulary::startsWith)) {
+      // If the cbv matches the curie urn then remove the prefix and return bare string
       return cbvVocabulary.substring(cbvVocabulary.lastIndexOf("-") + 1);
     }
     return cbvVocabulary;

--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -21,7 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.NONE)
-public class EventVocabularyFormatter {
+public class EventVocabularyFormatter implements VocabularyFormat {
   private static final String WEB_URI_PREFIX = "https://ref.gs1.org/cbv/";
   private static final String GS1_WEB_URI = "https://gs1.org/voc/";
   private static final String URN_PREFIX = "urn:epcglobal:cbv:";

--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -22,15 +22,19 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.NONE)
 public class EventVocabularyFormatter {
-
   private static final String WEB_URI_PREFIX = "https://ref.gs1.org/";
   private static final String URN_PREFIX = "urn:epcglobal:cbv:";
   private static final String WEBURI_FORMATTED = "WebURI";
   private static final String BIZ_STEP_URN_PREFIX = URN_PREFIX + "bizstep:";
+  private static final String BIZ_STEP_CURIE_PREFIX = "cbv:BizStep-";
   private static final String DISPOSITION_URN_PREFIX = URN_PREFIX + "disp:";
+  private static final String DISPOSITION_CURIE_PREFIX = "cbv:Disp-";
   private static final String BIZ_TRANSACTION_URN_PREFIX = URN_PREFIX + "btt:";
+  private static final String BIZ_TRANSACTION_CURIE_PREFIX = "cbv:BTT-";
   private static final String SRC_DEST_URN_PREFIX = URN_PREFIX + "sdt:";
+  private static final String SRC_DEST_CURIE_PREFIX = "cbv:SDT-";
   private static final String ERR_REASON_URN_PREFIX = URN_PREFIX + "er:";
+  private static final String ERR_REASON_CURIE_PREFIX = "cbv:ER-";
   private static final String BIZ_STEP_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/BizStep-";
   private static final String DISPOSITION_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/Disp-";
   private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = WEB_URI_PREFIX + "cbv/BTT-";
@@ -43,6 +47,14 @@ public class EventVocabularyFormatter {
           BIZ_TRANSACTION_URN_PREFIX,
           SRC_DEST_URN_PREFIX,
           ERR_REASON_URN_PREFIX);
+
+  private static final List<String> CURIE_FORMATTED_CBV_STRING =
+      Arrays.asList(
+          BIZ_STEP_CURIE_PREFIX,
+          DISPOSITION_CURIE_PREFIX,
+          BIZ_TRANSACTION_CURIE_PREFIX,
+          SRC_DEST_CURIE_PREFIX,
+          ERR_REASON_CURIE_PREFIX);
   private static final List<String> WEBURI_FORMATTED_CBV_STRING =
       Arrays.asList(
           BIZ_STEP_WEB_URI_PREFIX,
@@ -130,7 +142,9 @@ public class EventVocabularyFormatter {
       // Check if the CBV URN Vocabulary matches any of the pre-defined CBV URN string if so remove
       // the URN prefix and return bare string.
       return cbvVocabulary.substring(cbvVocabulary.lastIndexOf(":") + 1);
-
+    } else if (CURIE_FORMATTED_CBV_STRING.stream().anyMatch(cbvVocabulary::startsWith)) {
+      // If the cbv matches the curie urn then remove the prefix and return bare string
+      return cbvVocabulary.substring(cbvVocabulary.lastIndexOf("-") + 1);
     } else if (WEBURI_FORMATTED_CBV_STRING.stream().anyMatch(cbvVocabulary::startsWith)) {
       // Check if the CBV WebURI vocabulary matches any of the pre-defined CBV WebURI string if so
       // remove the WebURI prefix and return bare string.

--- a/src/main/java/io/openepcis/epc/translator/VocabularyFormat.java
+++ b/src/main/java/io/openepcis/epc/translator/VocabularyFormat.java
@@ -1,0 +1,3 @@
+package io.openepcis.epc.translator;
+
+public interface VocabularyFormat {}

--- a/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
@@ -57,6 +57,12 @@ public class BareStringVocabularyTest {
     bizStep = "cbv:BizStep-receiving";
     assertEquals("receiving", converter.toBareStringVocabulary(bizStep));
 
+    bizStep = "https://ref.gs1.org/cbv/BizStep-accepting";
+    assertEquals("accepting", converter.toBareStringVocabulary(bizStep));
+
+    bizStep = "https://ref.gs1.org/cbv/BizStep-disassembling";
+    assertEquals("disassembling", converter.toBareStringVocabulary(bizStep));
+
     assertEquals("cbv:receiving", converter.toBareStringVocabulary("cbv:receiving"));
     assertEquals("", converter.toBareStringVocabulary(""));
     assertEquals(" ", converter.toBareStringVocabulary(" "));
@@ -88,6 +94,12 @@ public class BareStringVocabularyTest {
 
     disposition = "cbv:Disp-in_progress";
     assertEquals("in_progress", converter.toBareStringVocabulary(disposition));
+
+    disposition = "https://ref.gs1.org/cbv/Disp-completeness_verified";
+    assertEquals("completeness_verified", converter.toBareStringVocabulary(disposition));
+
+    disposition = "https://ref.gs1.org/cbv/Disp-returned";
+    assertEquals("returned", converter.toBareStringVocabulary(disposition));
 
     assertEquals("cbv:in_progress", converter.toBareStringVocabulary("cbv:in_progress"));
   }
@@ -124,6 +136,12 @@ public class BareStringVocabularyTest {
 
     bizTransactionType = "cbv:BTT-desadv";
     assertEquals("desadv", converter.toBareStringVocabulary(bizTransactionType));
+
+    bizTransactionType = "https://ref.gs1.org/cbv/BTT-pedigree";
+    assertEquals("pedigree", converter.toBareStringVocabulary(bizTransactionType));
+
+    bizTransactionType = "https://ref.gs1.org/cbv/BTT-bol";
+    assertEquals("bol", converter.toBareStringVocabulary(bizTransactionType));
 
     assertEquals("cbv:desadv", converter.toBareStringVocabulary("cbv:desadv"));
   }
@@ -167,6 +185,12 @@ public class BareStringVocabularyTest {
     srcDestinationString = "cbv:SDT-owning_party";
     assertEquals("owning_party", converter.toBareStringVocabulary(srcDestinationString));
 
+    srcDestinationString = "https://ref.gs1.org/cbv/SDT-possessing_party";
+    assertEquals("possessing_party", converter.toBareStringVocabulary(srcDestinationString));
+
+    srcDestinationString = "https://ref.gs1.org/cbv/SDT-location";
+    assertEquals("location", converter.toBareStringVocabulary(srcDestinationString));
+
     assertEquals("cbv:owning_party", converter.toBareStringVocabulary("cbv:owning_party"));
   }
 
@@ -201,6 +225,12 @@ public class BareStringVocabularyTest {
 
     errorReason = "cbv:ER-did_not_occur";
     assertEquals("did_not_occur", converter.toBareStringVocabulary(errorReason));
+
+    errorReason = "https://ref.gs1.org/cbv/ER-did_not_occur";
+    assertEquals("did_not_occur", converter.toBareStringVocabulary(errorReason));
+
+    errorReason = "https://ref.gs1.org/cbv/ER-incorrect_data";
+    assertEquals("incorrect_data", converter.toBareStringVocabulary(errorReason));
 
     assertEquals("cbv:did_not_occur", converter.toBareStringVocabulary("cbv:did_not_occur"));
     assertEquals("", converter.toBareStringVocabulary(""));

--- a/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
@@ -54,6 +54,10 @@ public class BareStringVocabularyTest {
         "urn:example:department:bizstep:my_own_vocabulary",
         converter.toBareStringVocabulary(bizStep));
 
+    bizStep = "cbv:BizStep-receiving";
+    assertEquals("receiving", converter.toBareStringVocabulary(bizStep));
+
+    assertEquals("cbv:receiving", converter.toBareStringVocabulary("cbv:receiving"));
     assertEquals("", converter.toBareStringVocabulary(""));
     assertEquals(" ", converter.toBareStringVocabulary(" "));
     assertNull(converter.toBareStringVocabulary(null));
@@ -81,6 +85,11 @@ public class BareStringVocabularyTest {
     assertEquals(
         "urn:example:department:bizstep:my_own_vocabulary",
         converter.toBareStringVocabulary(disposition));
+
+    disposition = "cbv:Disp-in_progress";
+    assertEquals("in_progress", converter.toBareStringVocabulary(disposition));
+
+    assertEquals("cbv:in_progress", converter.toBareStringVocabulary("cbv:in_progress"));
   }
 
   @Test
@@ -112,6 +121,11 @@ public class BareStringVocabularyTest {
     assertEquals(
         "urn:example:department:error:custom_error",
         converter.toBareStringVocabulary(bizTransactionType));
+
+    bizTransactionType = "cbv:BTT-desadv";
+    assertEquals("desadv", converter.toBareStringVocabulary(bizTransactionType));
+
+    assertEquals("cbv:desadv", converter.toBareStringVocabulary("cbv:desadv"));
   }
 
   @Test
@@ -149,6 +163,11 @@ public class BareStringVocabularyTest {
 
     srcDestinationString = "mySource";
     assertEquals("mySource", converter.toBareStringVocabulary(srcDestinationString));
+
+    srcDestinationString = "cbv:SDT-owning_party";
+    assertEquals("owning_party", converter.toBareStringVocabulary(srcDestinationString));
+
+    assertEquals("cbv:owning_party", converter.toBareStringVocabulary("cbv:owning_party"));
   }
 
   @Test
@@ -180,6 +199,10 @@ public class BareStringVocabularyTest {
     assertEquals(
         "urn:example:error:reason:my_own_reason", converter.toBareStringVocabulary(errorReason));
 
+    errorReason = "cbv:ER-did_not_occur";
+    assertEquals("did_not_occur", converter.toBareStringVocabulary(errorReason));
+
+    assertEquals("cbv:did_not_occur", converter.toBareStringVocabulary("cbv:did_not_occur"));
     assertEquals("", converter.toBareStringVocabulary(""));
     assertEquals(" ", converter.toBareStringVocabulary(" "));
     assertNull(converter.toBareStringVocabulary(null));


### PR DESCRIPTION
This PR request will contain the logic to convert of the additional elements such as Curie Strings (cbv:Disp-in_progress) or GS1 formatted string (https://ref.gs1.org/cbv/ER-incorrect_data) into their respective bare string notation. The conversion logic will include following fields: bizStep, disposition, bizTransaction type, error reason, source/destination type.

This merge and build should fix the issue which has been created in [openepcis-document-converter](https://github.com/openepcis/openepcis-document-converter) repo (https://github.com/openepcis/openepcis-document-converter/issues/4)

I kindly request you to review and approve the PR.

