### PR TITLE
Feature/oepcis 494 fixing issues based on hash id rules

### DIFF
--- a/src/main/java/io/openepcis/epc/translator/Converter.java
+++ b/src/main/java/io/openepcis/epc/translator/Converter.java
@@ -269,7 +269,7 @@ public class Converter {
       final String bareString, final String fieldName, final String format) {
     return bareString == null || bareString.trim().equals("") || fieldName == null
         ? bareString
-        : eventVocabularyFormatter.cbvVocabulary(bareString, fieldName, format);
+        : eventVocabularyFormatter.toCbvVocabulary(bareString, fieldName, format);
   }
 
   /**

--- a/src/main/java/io/openepcis/epc/translator/Converter.java
+++ b/src/main/java/io/openepcis/epc/translator/Converter.java
@@ -21,6 +21,7 @@ import io.openepcis.epc.translator.exception.ValidationException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 
 public class Converter {
 
@@ -201,7 +202,7 @@ public class Converter {
    *     or https://ref.gs1.org/voc/BTT-po
    */
   public String toWebURIVocabulary(final String urnVocabulary) {
-    return urnVocabulary == null || urnVocabulary.trim().equals("")
+    return StringUtils.isBlank(urnVocabulary)
         ? urnVocabulary
         : eventVocabularyFormatter.canonicalWebURIVocabulary(urnVocabulary);
   }
@@ -215,7 +216,7 @@ public class Converter {
    *     urn:epcglobal:cbv:btt:po.
    */
   public String toUrnVocabulary(final String webUriVocabulary) {
-    return webUriVocabulary == null || webUriVocabulary.trim().equals("")
+    return StringUtils.isBlank(webUriVocabulary)
         ? webUriVocabulary
         : eventVocabularyFormatter.canonicalString(webUriVocabulary);
   }
@@ -228,7 +229,7 @@ public class Converter {
    * @return returns the converted bare string vocabulary ex: departing or receiving.
    */
   public String toBareStringVocabulary(final String eventVocabulary) {
-    return eventVocabulary == null || eventVocabulary.trim().equals("")
+    return StringUtils.isBlank(eventVocabulary)
         ? eventVocabulary
         : eventVocabularyFormatter.bareString(eventVocabulary);
   }
@@ -244,7 +245,9 @@ public class Converter {
    */
   public String toCbvVocabulary(
       final String bareString, final String fieldName, final String format) {
-    return bareString == null || bareString.trim().equals("") || fieldName == null
+    return StringUtils.isBlank(bareString)
+            || StringUtils.isBlank(fieldName)
+            || StringUtils.isBlank(format)
         ? bareString
         : eventVocabularyFormatter.toCbvVocabulary(bareString, fieldName, format);
   }
@@ -259,7 +262,7 @@ public class Converter {
    *     https://id.gs1.org/8004/401234599999
    */
   public final String shortNameReplacer(final String gs1Identifier) {
-    return gs1Identifier == null || gs1Identifier.trim().equals("")
+    return StringUtils.isBlank(gs1Identifier)
         ? gs1Identifier
         : eventVocabularyFormatter.shortNameReplacer(gs1Identifier);
   }

--- a/src/main/java/io/openepcis/epc/translator/Converter.java
+++ b/src/main/java/io/openepcis/epc/translator/Converter.java
@@ -18,6 +18,7 @@ package io.openepcis.epc.translator;
 import io.openepcis.epc.translator.converter.*;
 import io.openepcis.epc.translator.exception.UnsupportedGS1IdentifierException;
 import io.openepcis.epc.translator.exception.ValidationException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +31,8 @@ public class Converter {
   private final Set<io.openepcis.epc.translator.converter.Converter> classLevelTranslator =
       new HashSet<>();
   private final EventVocabularyFormatter eventVocabularyFormatter = new EventVocabularyFormatter();
+
+  private final Map<String, String> shortNameKeyIdentifier = new HashMap<>();
 
   public Converter() {
     // Add all EPC instance-level converter
@@ -57,6 +60,25 @@ public class Converter {
     classLevelTranslator.add(new GCNConverter(true));
     classLevelTranslator.add(new CPIConverter(true));
     classLevelTranslator.add(new ITIPConverter(true));
+
+    // Add the key value pair for the identifier
+    shortNameKeyIdentifier.put("/gtin/", "/01/");
+    shortNameKeyIdentifier.put("/itip/", "/8006/");
+    shortNameKeyIdentifier.put("/cpi/", "/8010/");
+    shortNameKeyIdentifier.put("/gln/", "/414/");
+    shortNameKeyIdentifier.put("/party/", "/417/");
+    shortNameKeyIdentifier.put("/gsrnp/", "/8017/");
+    shortNameKeyIdentifier.put("/gsrn/", "/8018/");
+    shortNameKeyIdentifier.put("/gcn/", "/255/");
+    shortNameKeyIdentifier.put("/sscc/", "/00/");
+    shortNameKeyIdentifier.put("/gdti/", "/253/");
+    shortNameKeyIdentifier.put("/ginc/", "/401/");
+    shortNameKeyIdentifier.put("/gsin/", "/402/");
+    shortNameKeyIdentifier.put("/grai/", "/8003/");
+    shortNameKeyIdentifier.put("/giai/", "/8004/");
+    shortNameKeyIdentifier.put("/cpv/", "/22/");
+    shortNameKeyIdentifier.put("/lot/", "/10/");
+    shortNameKeyIdentifier.put("/ser/", "/21/");
   }
 
   /**
@@ -247,5 +269,30 @@ public class Converter {
     return bareString == null || bareString.trim().equals("") || fieldName == null
         ? bareString
         : eventVocabularyFormatter.cbvVocabulary(bareString, fieldName, format);
+  }
+
+  /**
+   * Method to replace the short names for keys/key extensions with AIs. Used during sensorElement
+   * deviceId, rawData, etc. during pre-hash string generation in event hash generator.
+   *
+   * @param gs1Identifier GS1 WebURI vocabulary whose identifier vocabulary needs to be replaced ex:
+   *     https://example.org/giai/401234599999
+   * @return it would return the corresponding converted identifier ex:
+   *     https://id.gs1.org/8004/401234599999
+   */
+  public String shortNameReplacer(String gs1Identifier) {
+    // If the identifier contains any key from hash map replace with key extension number
+    for (Map.Entry<String, String> entry : shortNameKeyIdentifier.entrySet()) {
+      if (gs1Identifier.contains(entry.getKey())) {
+        if (!entry.getKey().equals("/lot/") && !entry.getKey().equals("/ser/")) {
+          gs1Identifier =
+              gs1Identifier.replace(
+                  gs1Identifier.substring(0, gs1Identifier.indexOf(entry.getKey())),
+                  "https://id.gs1.org");
+        }
+        gs1Identifier = gs1Identifier.replace(entry.getKey(), entry.getValue());
+      }
+    }
+    return gs1Identifier;
   }
 }

--- a/src/main/java/io/openepcis/epc/translator/Converter.java
+++ b/src/main/java/io/openepcis/epc/translator/Converter.java
@@ -15,11 +15,9 @@
  */
 package io.openepcis.epc.translator;
 
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.converter.*;
 import io.openepcis.epc.translator.exception.UnsupportedGS1IdentifierException;
 import io.openepcis.epc.translator.exception.ValidationException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -32,8 +30,6 @@ public class Converter {
   private final Set<io.openepcis.epc.translator.converter.Converter> classLevelTranslator =
       new HashSet<>();
   private final EventVocabularyFormatter eventVocabularyFormatter = new EventVocabularyFormatter();
-
-  private final Map<String, String> shortNameKeyIdentifier = new HashMap<>();
 
   public Converter() {
     // Add all EPC instance-level converter
@@ -61,25 +57,6 @@ public class Converter {
     classLevelTranslator.add(new GCNConverter(true));
     classLevelTranslator.add(new CPIConverter(true));
     classLevelTranslator.add(new ITIPConverter(true));
-
-    // Add the key value pair for the identifier
-    shortNameKeyIdentifier.put("/gtin/", "/01/");
-    shortNameKeyIdentifier.put("/itip/", "/8006/");
-    shortNameKeyIdentifier.put("/cpi/", "/8010/");
-    shortNameKeyIdentifier.put("/gln/", "/414/");
-    shortNameKeyIdentifier.put("/party/", "/417/");
-    shortNameKeyIdentifier.put("/gsrnp/", "/8017/");
-    shortNameKeyIdentifier.put("/gsrn/", "/8018/");
-    shortNameKeyIdentifier.put("/gcn/", "/255/");
-    shortNameKeyIdentifier.put("/sscc/", "/00/");
-    shortNameKeyIdentifier.put("/gdti/", "/253/");
-    shortNameKeyIdentifier.put("/ginc/", "/401/");
-    shortNameKeyIdentifier.put("/gsin/", "/402/");
-    shortNameKeyIdentifier.put("/grai/", "/8003/");
-    shortNameKeyIdentifier.put("/giai/", "/8004/");
-    shortNameKeyIdentifier.put("/cpv/", "/22/");
-    shortNameKeyIdentifier.put("/lot/", "/10/");
-    shortNameKeyIdentifier.put("/ser/", "/21/");
   }
 
   /**
@@ -281,27 +258,9 @@ public class Converter {
    * @return it would return the corresponding converted identifier ex:
    *     https://id.gs1.org/8004/401234599999
    */
-  public final String shortNameReplacer(String gs1Identifier) {
-    // If the identifier contains any key from hash map replace with key extension number
-    for (Map.Entry<String, String> entry : shortNameKeyIdentifier.entrySet()) {
-      if (gs1Identifier.contains(entry.getKey())) {
-        if (!entry.getKey().equals("/lot/") && !entry.getKey().equals("/ser/")) {
-          gs1Identifier =
-              gs1Identifier.replace(
-                  gs1Identifier.substring(0, gs1Identifier.indexOf(entry.getKey())),
-                  Constants.GS1_IDENTIFIER_DOMAIN);
-        }
-        gs1Identifier = gs1Identifier.replace(entry.getKey(), entry.getValue());
-      } else if (gs1Identifier.contains(entry.getValue())
-          && (!entry.getKey().equals("/10/") && !entry.getKey().equals("/21/"))
-          && !gs1Identifier.startsWith(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        // If the identifier key is already present then only replace the domain to GS1
-        gs1Identifier =
-            gs1Identifier.replace(
-                gs1Identifier.substring(0, gs1Identifier.indexOf(entry.getValue())),
-                Constants.GS1_IDENTIFIER_DOMAIN);
-      }
-    }
-    return gs1Identifier;
+  public final String shortNameReplacer(final String gs1Identifier) {
+    return gs1Identifier == null || gs1Identifier.trim().equals("")
+        ? gs1Identifier
+        : eventVocabularyFormatter.shortNameReplacer(gs1Identifier);
   }
 }

--- a/src/main/java/io/openepcis/epc/translator/Converter.java
+++ b/src/main/java/io/openepcis/epc/translator/Converter.java
@@ -15,6 +15,7 @@
  */
 package io.openepcis.epc.translator;
 
+import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.converter.*;
 import io.openepcis.epc.translator.exception.UnsupportedGS1IdentifierException;
 import io.openepcis.epc.translator.exception.ValidationException;
@@ -280,7 +281,7 @@ public class Converter {
    * @return it would return the corresponding converted identifier ex:
    *     https://id.gs1.org/8004/401234599999
    */
-  public String shortNameReplacer(String gs1Identifier) {
+  public final String shortNameReplacer(String gs1Identifier) {
     // If the identifier contains any key from hash map replace with key extension number
     for (Map.Entry<String, String> entry : shortNameKeyIdentifier.entrySet()) {
       if (gs1Identifier.contains(entry.getKey())) {
@@ -288,9 +289,17 @@ public class Converter {
           gs1Identifier =
               gs1Identifier.replace(
                   gs1Identifier.substring(0, gs1Identifier.indexOf(entry.getKey())),
-                  "https://id.gs1.org");
+                  Constants.GS1_IDENTIFIER_DOMAIN);
         }
         gs1Identifier = gs1Identifier.replace(entry.getKey(), entry.getValue());
+      } else if (gs1Identifier.contains(entry.getValue())
+          && (!entry.getKey().equals("/10/") && !entry.getKey().equals("/21/"))
+          && !gs1Identifier.startsWith(Constants.GS1_IDENTIFIER_DOMAIN)) {
+        // If the identifier key is already present then only replace the domain to GS1
+        gs1Identifier =
+            gs1Identifier.replace(
+                gs1Identifier.substring(0, gs1Identifier.indexOf(entry.getValue())),
+                Constants.GS1_IDENTIFIER_DOMAIN);
       }
     }
     return gs1Identifier;

--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -15,6 +15,8 @@
  */
 package io.openepcis.epc.translator;
 
+import static io.openepcis.epc.translator.constants.Constants.*;
+
 import io.openepcis.epc.translator.constants.Constants;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -22,30 +24,26 @@ import java.util.List;
 import java.util.Map;
 
 public class EventVocabularyFormatter implements VocabularyFormat {
-  private static final String WEB_URI_PREFIX = "https://ref.gs1.org/cbv/";
-  private static final String GS1_WEB_URI = "https://gs1.org/voc/";
-  private static final String URN_PREFIX = "urn:epcglobal:cbv:";
-  private static final String WEBURI_FORMATTED = "WebURI";
-  private static final String BIZ_STEP_URN_PREFIX = URN_PREFIX + "bizstep:";
+  private static final String BIZ_STEP_URN_PREFIX = GS1_URN_CBV_PREFIX + "bizstep:";
   private static final String BIZ_STEP_CURIE_PREFIX = "cbv:BizStep-";
-  private static final String DISPOSITION_URN_PREFIX = URN_PREFIX + "disp:";
+  private static final String DISPOSITION_URN_PREFIX = GS1_URN_CBV_PREFIX + "disp:";
   private static final String DISPOSITION_CURIE_PREFIX = "cbv:Disp-";
-  private static final String BIZ_TRANSACTION_URN_PREFIX = URN_PREFIX + "btt:";
+  private static final String BIZ_TRANSACTION_URN_PREFIX = GS1_URN_CBV_PREFIX + "btt:";
   private static final String BIZ_TRANSACTION_CURIE_PREFIX = "cbv:BTT-";
-  private static final String SRC_DEST_URN_PREFIX = URN_PREFIX + "sdt:";
+  private static final String SRC_DEST_URN_PREFIX = GS1_URN_CBV_PREFIX + "sdt:";
   private static final String SRC_DEST_CURIE_PREFIX = "cbv:SDT-";
-  private static final String ERR_REASON_URN_PREFIX = URN_PREFIX + "er:";
+  private static final String ERR_REASON_URN_PREFIX = GS1_URN_CBV_PREFIX + "er:";
   private static final String ERR_REASON_CURIE_PREFIX = "cbv:ER-";
-  private static final String BIZ_STEP_WEB_URI_PREFIX = WEB_URI_PREFIX + "BizStep-";
-  private static final String DISPOSITION_WEB_URI_PREFIX = WEB_URI_PREFIX + "Disp-";
-  private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = WEB_URI_PREFIX + "BTT-";
-  private static final String SRC_DEST_WEB_URI_PREFIX = WEB_URI_PREFIX + "SDT-";
-  private static final String ERR_REASON_WEB_URI_PREFIX = WEB_URI_PREFIX + "ER-";
-  private static final String BIZ_STEP_GS1_PREFIX = GS1_WEB_URI + "BizStep-";
-  private static final String DISPOSITION_GS1_PREFIX = GS1_WEB_URI + "Disp-";
-  private static final String BIZ_TRANSACTION_GS1_PREFIX = GS1_WEB_URI + "BTT-";
-  private static final String SRC_DEST_GS1_PREFIX = GS1_WEB_URI + "SDT-";
-  private static final String ERR_REASON_GS1_PREFIX = GS1_WEB_URI + "ER-";
+  private static final String BIZ_STEP_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "BizStep-";
+  private static final String DISPOSITION_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "Disp-";
+  private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "BTT-";
+  private static final String SRC_DEST_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "SDT-";
+  private static final String ERR_REASON_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "ER-";
+  private static final String BIZ_STEP_GS1_PREFIX = GS1_VOC_DOMAIN + "BizStep-";
+  private static final String DISPOSITION_GS1_PREFIX = GS1_VOC_DOMAIN + "Disp-";
+  private static final String BIZ_TRANSACTION_GS1_PREFIX = GS1_VOC_DOMAIN + "BTT-";
+  private static final String SRC_DEST_GS1_PREFIX = GS1_VOC_DOMAIN + "SDT-";
+  private static final String ERR_REASON_GS1_PREFIX = GS1_VOC_DOMAIN + "ER-";
   private static final List<String> URN_FORMATTED_CBV_STRING =
       Arrays.asList(
           BIZ_STEP_URN_PREFIX,
@@ -75,10 +73,10 @@ public class EventVocabularyFormatter implements VocabularyFormat {
 
   private static final Map<String, String> CURIE_PREFIX_MAPPER = new HashMap<>();
 
-  private final Map<String, String> shortNameKeyIdentifier = new HashMap<>();
-  private final List<String> excludeSerial = List.of("/lot/", "/ser/", "/10/", "/21/");
+  private static final Map<String, String> shortNameKeyIdentifier = new HashMap<>();
+  private static final List<String> excludeSerial = List.of("/lot/", "/ser/", "/10/", "/21/");
 
-  public EventVocabularyFormatter() {
+  static {
     CURIE_PREFIX_MAPPER.put("bizstep", BIZ_STEP_CURIE_PREFIX);
     CURIE_PREFIX_MAPPER.put("disposition", DISPOSITION_CURIE_PREFIX);
     CURIE_PREFIX_MAPPER.put("persistentdisposition", DISPOSITION_CURIE_PREFIX);
@@ -207,7 +205,6 @@ public class EventVocabularyFormatter implements VocabularyFormat {
   // during JSON/JSON-LD -> XML conversion.
   public String toCbvVocabulary(
       final String bareString, final String fieldName, final String format) {
-
     String prefix;
     String bareStringValue = curieStringFinder(fieldName, bareString);
 
@@ -265,6 +262,7 @@ public class EventVocabularyFormatter implements VocabularyFormat {
   // Method to check if the value matches any of the curie string if so format according to curie
   // string
   private String curieStringFinder(final String fieldName, String fieldValue) {
+
     String prefix = CURIE_PREFIX_MAPPER.get(fieldName.toLowerCase());
 
     if (prefix == null) {

--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -209,7 +209,7 @@ public class EventVocabularyFormatter implements VocabularyFormat {
       final String bareString, final String fieldName, final String format) {
 
     String prefix;
-    String value = curieStringFinder(fieldName, bareString);
+    String bareStringValue = curieStringFinder(fieldName, bareString);
 
     // Check for the fieldName and based on that return the respective CBV formatted vocabulary in
     // either WebURI or URN format.
@@ -254,7 +254,12 @@ public class EventVocabularyFormatter implements VocabularyFormat {
       default:
         return bareString;
     }
-    return prefix + value;
+
+    // If bareString value contains any of the GS1 standard character then return the same if not
+    // send transformed value with prefix.
+    return bareStringValue.contains(":") || bareStringValue.contains("/")
+        ? bareStringValue
+        : prefix + bareStringValue;
   }
 
   // Method to check if the value matches any of the curie string if so format according to curie

--- a/src/main/java/io/openepcis/epc/translator/constants/Constants.java
+++ b/src/main/java/io/openepcis/epc/translator/constants/Constants.java
@@ -21,9 +21,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Constants {
   public static final String GS1_IDENTIFIER_DOMAIN = "https://id.gs1.org";
+  public static final String GS1_CBV_DOMAIN = "https://ref.gs1.org/cbv/";
+  public static final String GS1_VOC_DOMAIN = "https://gs1.org/voc/";
+  public static final String GS1_URN_CBV_PREFIX = "urn:epcglobal:cbv:";
+
   public static final String AS_CAPTURED = "asCaptured";
   public static final String CANONICAL_DL = "canonicalDL";
   public static final String AS_URN = "asURN";
   public static final String SERIAL = "serial";
   public static final String GCP_LENGTH = " GCP Length : ";
+  public static final String WEBURI_FORMATTED = "WebURI";
 }

--- a/src/main/java/io/openepcis/epc/translator/constants/StandardVocabElements.java
+++ b/src/main/java/io/openepcis/epc/translator/constants/StandardVocabElements.java
@@ -18,13 +18,13 @@ package io.openepcis.epc.translator.constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 
 public enum StandardVocabElements {
-  BIZ_STEP("urn:epcglobal:cbv:bizstep:", "https://ns.gs1.org/cbv/Bizstep-"),
-  DISPOSITION("urn:epcglobal:cbv:disp:", "https://ns.gs1.org/cbv/Disp-"),
-  BIZ_TRANSACTION_TYPE("urn:epcglobal:cbv:btt:", "https://ns.gs1.org/cbv/BTT-"),
-  SOURCE_DEST_TYPE("urn:epcglobal:cbv:sdt:", "https://ns.gs1.org/cbv/SDT-"),
-  ERROR_REASON("urn:epcglobal:cbv:er:", "https://ns.gs1.org/cbv/ER-"),
-  MEASUREMENT_TYPE("gs1:", "https://gs1.org/voc/"),
-  ALERT_TYPE("gs1:", "https://gs1.org/voc/");
+  BIZ_STEP("urn:epcglobal:cbv:bizstep:", Constants.GS1_CBV_DOMAIN + "Bizstep-"),
+  DISPOSITION("urn:epcglobal:cbv:disp:", Constants.GS1_CBV_DOMAIN + "Disp-"),
+  BIZ_TRANSACTION_TYPE("urn:epcglobal:cbv:btt:", Constants.GS1_CBV_DOMAIN + "BTT-"),
+  SOURCE_DEST_TYPE("urn:epcglobal:cbv:sdt:", Constants.GS1_CBV_DOMAIN + "SDT-"),
+  ERROR_REASON("urn:epcglobal:cbv:er:", Constants.GS1_CBV_DOMAIN + "ER-"),
+  MEASUREMENT_TYPE("gs1:", Constants.GS1_VOC_DOMAIN),
+  ALERT_TYPE("gs1:", Constants.GS1_VOC_DOMAIN);
 
   private final String urnPrefix;
   private final String dlPrefix;

--- a/src/main/java/io/openepcis/epc/translator/converter/SGLNConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/SGLNConverter.java
@@ -63,7 +63,11 @@ public class SGLNConverter implements Converter {
       if (serial.length() == 0) {
         return Constants.GS1_IDENTIFIER_DOMAIN + SGLN_URI_PART + sgln;
       } else {
-        return Constants.GS1_IDENTIFIER_DOMAIN + SGLN_URI_PART + sgln + SGLN_SERIAL_PART + serial;
+        // Add serial part if not 0
+        return Constants.GS1_IDENTIFIER_DOMAIN
+            + SGLN_URI_PART
+            + sgln
+            + ((!serial.equals("0")) ? SGLN_SERIAL_PART + serial : "");
       }
     } catch (Exception exception) {
       throw new ValidationException(

--- a/src/main/java/io/openepcis/epc/translator/util/ConverterUtil.java
+++ b/src/main/java/io/openepcis/epc/translator/util/ConverterUtil.java
@@ -71,4 +71,9 @@ public class ConverterUtil {
       final String bareString, final String fieldName, final String format) {
     return converter.toCbvVocabulary(bareString, fieldName, format);
   }
+
+  // Convert the short names with corresponding identifier
+  public static String shortNameReplacer(final String gs1Identifier) {
+    return converter.shortNameReplacer(gs1Identifier);
+  }
 }

--- a/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/BareStringVocabularyTest.java
@@ -102,6 +102,7 @@ public class BareStringVocabularyTest {
     assertEquals("returned", converter.toBareStringVocabulary(disposition));
 
     assertEquals("cbv:in_progress", converter.toBareStringVocabulary("cbv:in_progress"));
+    assertNull(converter.toBareStringVocabulary(null));
   }
 
   @Test
@@ -144,6 +145,7 @@ public class BareStringVocabularyTest {
     assertEquals("bol", converter.toBareStringVocabulary(bizTransactionType));
 
     assertEquals("cbv:desadv", converter.toBareStringVocabulary("cbv:desadv"));
+    assertNull(converter.toBareStringVocabulary(null));
   }
 
   @Test
@@ -192,6 +194,7 @@ public class BareStringVocabularyTest {
     assertEquals("location", converter.toBareStringVocabulary(srcDestinationString));
 
     assertEquals("cbv:owning_party", converter.toBareStringVocabulary("cbv:owning_party"));
+    assertNull(converter.toBareStringVocabulary(null));
   }
 
   @Test

--- a/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
@@ -67,6 +67,10 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:epcglobal:cbv:bizstep:shipping",
         converter.toCbvVocabulary("cbv:BizStep-shipping", "bizStep", "urn"));
+
+    assertEquals(
+        "urn:gs1:epcisapp:rail:BizStep:shipping",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:BizStep:shipping", "bizStep", "urn"));
   }
 
   @Test
@@ -116,6 +120,10 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:epcglobal:cbv:disp:in_progress",
         converter.toCbvVocabulary("cbv:Disp-in_progress", "disposition", "Urn"));
+
+    assertEquals(
+        "urn:gs1:epcisapp:rail:Disp:in_progress",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:Disp:in_progress", "disposition", "urn"));
   }
 
   @Test
@@ -156,6 +164,10 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:epcglobal:cbv:btt:inv",
         converter.toCbvVocabulary("cbv:BTT-inv", "bizTransaction", "Urn"));
+
+    assertEquals(
+        "urn:gs1:epcisapp:rail:btt:passage",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:btt:passage", "bizTransaction", "weburi"));
   }
 
   @Test
@@ -220,6 +232,10 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:epcglobal:cbv:sdt:location",
         converter.toCbvVocabulary("cbv:SDT-location", "Destination", "Urn"));
+
+    assertEquals(
+        "urn:gs1:epcisapp:rail:SDT:location",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:SDT:location", "destination", "urn"));
   }
 
   @Test
@@ -258,5 +274,9 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:epcglobal:cbv:er:did_not_occur",
         converter.toCbvVocabulary("cbv:ER-did_not_occur", "reason", "Urn"));
+
+    assertEquals(
+        "urn:gs1:epcisapp:rail:er:did_not_occur",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:er:did_not_occur", "reason", "WebURI"));
   }
 }

--- a/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
@@ -53,6 +53,20 @@ public class CbvVocabularyTest {
     assertEquals(" ", converter.toCbvVocabulary(" ", "bizStep", "urn"));
     assertNull(converter.toCbvVocabulary(null, "bizStep", "webUri"));
     assertEquals("shipping", converter.toCbvVocabulary("shipping", null, "webUri"));
+
+    assertEquals(
+        "https://ref.gs1.org/cbv/BizStep-receiving",
+        converter.toCbvVocabulary("cbv:BizStep-receiving", "bizStep", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/BizStep-packing",
+        converter.toCbvVocabulary("cbv:BizStep-packing", "bizStep", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/BizStep-shipping",
+        converter.toCbvVocabulary("cbv:BizStep-shipping", "bizStep", "webUri"));
+
+    assertEquals(
+        "urn:epcglobal:cbv:bizstep:shipping",
+        converter.toCbvVocabulary("cbv:BizStep-shipping", "bizStep", "urn"));
   }
 
   @Test
@@ -88,6 +102,20 @@ public class CbvVocabularyTest {
     assertEquals(
         "https://ref.gs1.org/cbv/Disp-partially_dispensed",
         converter.toCbvVocabulary("partially_dispensed", "persistentDisposition", "WebURI"));
+
+    assertEquals(
+        "https://ref.gs1.org/cbv/Disp-partially_dispensed",
+        converter.toCbvVocabulary("cbv:Disp-partially_dispensed", "disposition", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/Disp-in_transit",
+        converter.toCbvVocabulary("cbv:Disp-in_transit", "disposition", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/Disp-in_progress",
+        converter.toCbvVocabulary("cbv:Disp-in_progress", "disposition", "webUri"));
+
+    assertEquals(
+        "urn:epcglobal:cbv:disp:in_progress",
+        converter.toCbvVocabulary("cbv:Disp-in_progress", "disposition", "Urn"));
   }
 
   @Test
@@ -111,6 +139,23 @@ public class CbvVocabularyTest {
     assertEquals(
         "https://ref.gs1.org/cbv/BTT-pedigree",
         converter.toCbvVocabulary("pedigree", "bizTransaction", "webURi"));
+
+    assertEquals(
+        "https://ref.gs1.org/cbv/BTT-po",
+        converter.toCbvVocabulary("cbv:BTT-po", "bizTransaction", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/BTT-inv",
+        converter.toCbvVocabulary("cbv:BTT-inv", "bizTransactionList", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/BTT-pedigree",
+        converter.toCbvVocabulary("cbv:BTT-pedigree", "bizTransaction", "webUri"));
+
+    assertEquals(
+        "urn:epcglobal:cbv:btt:po",
+        converter.toCbvVocabulary("cbv:BTT-po", "bizTransaction", "Urn"));
+    assertEquals(
+        "urn:epcglobal:cbv:btt:inv",
+        converter.toCbvVocabulary("cbv:BTT-inv", "bizTransaction", "Urn"));
   }
 
   @Test
@@ -158,6 +203,23 @@ public class CbvVocabularyTest {
     assertEquals(
         "https://ref.gs1.org/cbv/SDT-processing_party",
         converter.toCbvVocabulary("processing_party", "Destination", "weburi"));
+
+    assertEquals(
+        "https://ref.gs1.org/cbv/SDT-processing_party",
+        converter.toCbvVocabulary("cbv:SDT-processing_party", "destinationList", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/SDT-location",
+        converter.toCbvVocabulary("cbv:SDT-location", "source", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/SDT-owning_party",
+        converter.toCbvVocabulary("cbv:SDT-owning_party", "Destination", "webUri"));
+
+    assertEquals(
+        "urn:epcglobal:cbv:sdt:owning_party",
+        converter.toCbvVocabulary("cbv:SDT-owning_party", "source", "Urn"));
+    assertEquals(
+        "urn:epcglobal:cbv:sdt:location",
+        converter.toCbvVocabulary("cbv:SDT-location", "Destination", "Urn"));
   }
 
   @Test
@@ -182,5 +244,19 @@ public class CbvVocabularyTest {
         converter.toCbvVocabulary("incorrect_data", "reason", "WebURI"));
     assertEquals(
         "https://ref.gs1.org/cbv/ER-other", converter.toCbvVocabulary("other", "reason", "WebURI"));
+
+    assertEquals(
+        "https://ref.gs1.org/cbv/ER-did_not_occur",
+        converter.toCbvVocabulary("cbv:ER-did_not_occur", "reason", "webUri"));
+    assertEquals(
+        "https://ref.gs1.org/cbv/ER-incorrect_data",
+        converter.toCbvVocabulary("cbv:ER-incorrect_data", "reason", "webUri"));
+
+    assertEquals(
+        "urn:epcglobal:cbv:er:other",
+        converter.toCbvVocabulary("cbv:ER-other", "errorDeclaration", "Urn"));
+    assertEquals(
+        "urn:epcglobal:cbv:er:did_not_occur",
+        converter.toCbvVocabulary("cbv:ER-did_not_occur", "reason", "Urn"));
   }
 }

--- a/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/CbvVocabularyTest.java
@@ -71,6 +71,14 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:gs1:epcisapp:rail:BizStep:shipping",
         converter.toCbvVocabulary("urn:gs1:epcisapp:rail:BizStep:shipping", "bizStep", "urn"));
+
+    assertNull(converter.toCbvVocabulary(null, "bizStep", "urn"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:BizStep:shipping",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:BizStep:shipping", null, "urn"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:BizStep:shipping",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:BizStep:shipping", "bizStep", null));
   }
 
   @Test
@@ -124,6 +132,15 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:gs1:epcisapp:rail:Disp:in_progress",
         converter.toCbvVocabulary("urn:gs1:epcisapp:rail:Disp:in_progress", "disposition", "urn"));
+
+    assertNull(converter.toCbvVocabulary(null, "disposition", "urn"));
+    assertNull(converter.toCbvVocabulary(null, "disposition", "webURI"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:Disp:in_progress",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:Disp:in_progress", null, "urn"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:Disp:in_progress",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:Disp:in_progress", "disposition", null));
   }
 
   @Test
@@ -168,6 +185,15 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:gs1:epcisapp:rail:btt:passage",
         converter.toCbvVocabulary("urn:gs1:epcisapp:rail:btt:passage", "bizTransaction", "weburi"));
+
+    assertNull(converter.toCbvVocabulary(null, "bizTransaction", "urn"));
+    assertNull(converter.toCbvVocabulary(null, "bizTransaction", "webURI"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:btt:passage",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:btt:passage", null, "urn"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:btt:passage",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:btt:passage", "bizTransaction", null));
   }
 
   @Test
@@ -236,6 +262,16 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:gs1:epcisapp:rail:SDT:location",
         converter.toCbvVocabulary("urn:gs1:epcisapp:rail:SDT:location", "destination", "urn"));
+
+    assertNull(converter.toCbvVocabulary(null, "destination", "urn"));
+    assertNull(converter.toCbvVocabulary(null, "destination", "webURI"));
+    assertEquals(" ", converter.toCbvVocabulary(" ", null, "urn"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:SDT:location",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:SDT:location", null, "urn"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:SDT:location",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:SDT:location", "destination", null));
   }
 
   @Test
@@ -278,5 +314,15 @@ public class CbvVocabularyTest {
     assertEquals(
         "urn:gs1:epcisapp:rail:er:did_not_occur",
         converter.toCbvVocabulary("urn:gs1:epcisapp:rail:er:did_not_occur", "reason", "WebURI"));
+
+    assertNull(converter.toCbvVocabulary(null, "reason", "urn"));
+    assertNull(converter.toCbvVocabulary(null, "reason", "webURI"));
+    assertEquals(" ", converter.toCbvVocabulary(" ", "reason", "urn"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:er:did_not_occur",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:er:did_not_occur", null, "urn"));
+    assertEquals(
+        "urn:gs1:epcisapp:rail:er:did_not_occur",
+        converter.toCbvVocabulary("urn:gs1:epcisapp:rail:er:did_not_occur", "reason", null));
   }
 }

--- a/src/test/java/io/openepcis/epc/translator/tests/SGLNTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/SGLNTest.java
@@ -70,14 +70,12 @@ public class SGLNTest {
         "https://id.gs1.org/414/4374736473640/254/\"%&'()*+,-./19:;<=>?",
         converter.toURI("urn:epc:id:sgln:437473647364..\"%&'()*+,-./19:;<=>?"));
     assertEquals(
-        "https://id.gs1.org/414/4374736473640/254/0",
-        converter.toURI("urn:epc:id:sgln:437473647364..0"));
+        "https://id.gs1.org/414/4374736473640", converter.toURI("urn:epc:id:sgln:437473647364..0"));
     assertEquals(
         "https://id.gs1.org/414/7857834384782/254/0394903",
         converter.toURI("urn:epc:id:sgln:785783.438478.0394903"));
     assertEquals(
-        "https://id.gs1.org/414/4374736473640/254/0",
-        converter.toURI("urn:epc:id:sgln:4374736473.64.0"));
+        "https://id.gs1.org/414/4374736473640", converter.toURI("urn:epc:id:sgln:4374736473.64.0"));
 
     // SGLN URI with invalid format
     sgln = "hps://id.gs1.org/414/1234567890123/254/1111";

--- a/src/test/java/io/openepcis/epc/translator/tests/ShortNameReplacerTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/ShortNameReplacerTest.java
@@ -80,5 +80,7 @@ public class ShortNameReplacerTest {
     assertEquals(
         "https://id.gs1.org/01/84384384898340/21/894893894838934893",
         converter.shortNameReplacer(gs1Identifier));
+    assertEquals(null, converter.shortNameReplacer(null));
+    assertEquals("", converter.shortNameReplacer(""));
   }
 }

--- a/src/test/java/io/openepcis/epc/translator/tests/ShortNameReplacerTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/ShortNameReplacerTest.java
@@ -1,0 +1,70 @@
+package io.openepcis.epc.translator.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import io.openepcis.epc.translator.Converter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShortNameReplacerTest {
+
+  private Converter converter;
+
+  @Before
+  public void before() throws Exception {
+    converter = new Converter();
+  }
+
+  @Test
+  public void ShortNameReplaceTest() {
+    String gs1Identifier = "https://example.org/giai/401234599999";
+    assertEquals(
+        "https://id.gs1.org/8004/401234599999", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://example.com/gdti/4012345000054987";
+    assertEquals(
+        "https://id.gs1.org/253/4012345000054987", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://www.ncbi.nlm.nih.gov/taxonomy/1126011";
+    assertEquals(
+        "https://www.ncbi.nlm.nih.gov/taxonomy/1126011",
+        converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N";
+    assertEquals(
+        "https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N",
+        converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://example.org/giai/401234599999";
+    assertEquals(
+        "https://id.gs1.org/8004/401234599999", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://id.gs1.org/giai/4000001111";
+    assertEquals("https://id.gs1.org/8004/4000001111", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://hello.comain//cpi/381366783201294-5A";
+    assertEquals(
+        "https://id.gs1.org/8010/381366783201294-5A", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://id.gs1.org/gln/1234567890111";
+    assertEquals(
+        "https://id.gs1.org/414/1234567890111", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://id.gs1.org/gcn/4343884394893";
+    assertEquals(
+        "https://id.gs1.org/255/4343884394893", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://myownDomain/gtin/12345678901231/ser/9999";
+    assertEquals(
+        "https://id.gs1.org/01/12345678901231/21/9999", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "testing:123";
+    assertEquals("testing:123", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "urn:epc:id:gsin:8439589358.953939";
+    assertEquals("urn:epc:id:gsin:8439589358.953939", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://id.example/4343884394893";
+    assertEquals("https://id.example/4343884394893", converter.shortNameReplacer(gs1Identifier));
+  }
+}

--- a/src/test/java/io/openepcis/epc/translator/tests/ShortNameReplacerTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/ShortNameReplacerTest.java
@@ -70,5 +70,15 @@ public class ShortNameReplacerTest {
     gs1Identifier = "https://example.com/253/4012345000054987";
     assertEquals(
         "https://id.gs1.org/253/4012345000054987", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://id.gs1.de/01/04012345999990/21/XYZ-1234";
+    assertEquals(
+        "https://id.gs1.org/01/04012345999990/21/XYZ-1234",
+        converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://id.gs1.de/01/84384384898340/ser/894893894838934893";
+    assertEquals(
+        "https://id.gs1.org/01/84384384898340/21/894893894838934893",
+        converter.shortNameReplacer(gs1Identifier));
   }
 }

--- a/src/test/java/io/openepcis/epc/translator/tests/ShortNameReplacerTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/ShortNameReplacerTest.java
@@ -66,5 +66,9 @@ public class ShortNameReplacerTest {
 
     gs1Identifier = "https://id.example/4343884394893";
     assertEquals("https://id.example/4343884394893", converter.shortNameReplacer(gs1Identifier));
+
+    gs1Identifier = "https://example.com/253/4012345000054987";
+    assertEquals(
+        "https://id.gs1.org/253/4012345000054987", converter.shortNameReplacer(gs1Identifier));
   }
 }

--- a/src/test/java/io/openepcis/epc/translator/tests/UrnVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/UrnVocabularyTest.java
@@ -73,6 +73,9 @@ public class UrnVocabularyTest {
     assertEquals(
         "https://example.com/department/My_Own_Disposition",
         converter.toUrnVocabulary(disposition));
+
+    assertEquals(null, converter.toUrnVocabulary(null));
+    assertEquals("", converter.toUrnVocabulary(""));
   }
 
   @Test

--- a/src/test/java/io/openepcis/epc/translator/tests/WebURIVocabularyTest.java
+++ b/src/test/java/io/openepcis/epc/translator/tests/WebURIVocabularyTest.java
@@ -81,6 +81,9 @@ public class WebURIVocabularyTest {
     assertEquals(
         "urn:example:department:disposition:custom_disposition",
         converter.toWebURIVocabulary(disposition));
+
+    assertEquals(null, converter.toWebURIVocabulary(null));
+    assertEquals("", converter.toWebURIVocabulary(""));
   }
 
   @Test


### PR DESCRIPTION
This PR will add the methods to convert convert the identifier from they key to respective identifier associated with them such as `giai` to `8004` which is required during the pre-hash string generation in event hash generator. Also, includes some fixes to bareString, CBV vocabulary conversion and some enhancement.

This along with PR: https://github.com/openepcis/openepcis-event-hash-generator/pull/10 should fix the issue: https://github.com/openepcis/openepcis-event-hash-generator/issues/9 and many other issues in pre-hash string.

Kindly request you to approve the PR and merge. 