### PR TITLE
using constant info from openepcis-constants instead of project specific constants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,14 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+
+        <!-- Add constants as dependencies -->
+        <dependency>
+            <groupId>io.openepcis</groupId>
+            <artifactId>openepcis-epcis-constants</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
+++ b/src/main/java/io/openepcis/epc/translator/EventVocabularyFormatter.java
@@ -15,61 +15,41 @@
  */
 package io.openepcis.epc.translator;
 
-import static io.openepcis.epc.translator.constants.Constants.*;
+import static io.openepcis.constants.EPCIS.WEBURI;
 
-import io.openepcis.epc.translator.constants.Constants;
+import io.openepcis.constants.EPCIS;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class EventVocabularyFormatter implements VocabularyFormat {
-  private static final String BIZ_STEP_URN_PREFIX = GS1_URN_CBV_PREFIX + "bizstep:";
-  private static final String BIZ_STEP_CURIE_PREFIX = "cbv:BizStep-";
-  private static final String DISPOSITION_URN_PREFIX = GS1_URN_CBV_PREFIX + "disp:";
-  private static final String DISPOSITION_CURIE_PREFIX = "cbv:Disp-";
-  private static final String BIZ_TRANSACTION_URN_PREFIX = GS1_URN_CBV_PREFIX + "btt:";
-  private static final String BIZ_TRANSACTION_CURIE_PREFIX = "cbv:BTT-";
-  private static final String SRC_DEST_URN_PREFIX = GS1_URN_CBV_PREFIX + "sdt:";
-  private static final String SRC_DEST_CURIE_PREFIX = "cbv:SDT-";
-  private static final String ERR_REASON_URN_PREFIX = GS1_URN_CBV_PREFIX + "er:";
-  private static final String ERR_REASON_CURIE_PREFIX = "cbv:ER-";
-  private static final String BIZ_STEP_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "BizStep-";
-  private static final String DISPOSITION_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "Disp-";
-  private static final String BIZ_TRANSACTION_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "BTT-";
-  private static final String SRC_DEST_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "SDT-";
-  private static final String ERR_REASON_WEB_URI_PREFIX = GS1_CBV_DOMAIN + "ER-";
-  private static final String BIZ_STEP_GS1_PREFIX = GS1_VOC_DOMAIN + "BizStep-";
-  private static final String DISPOSITION_GS1_PREFIX = GS1_VOC_DOMAIN + "Disp-";
-  private static final String BIZ_TRANSACTION_GS1_PREFIX = GS1_VOC_DOMAIN + "BTT-";
-  private static final String SRC_DEST_GS1_PREFIX = GS1_VOC_DOMAIN + "SDT-";
-  private static final String ERR_REASON_GS1_PREFIX = GS1_VOC_DOMAIN + "ER-";
   private static final List<String> URN_FORMATTED_CBV_STRING =
       Arrays.asList(
-          BIZ_STEP_URN_PREFIX,
-          DISPOSITION_URN_PREFIX,
-          BIZ_TRANSACTION_URN_PREFIX,
-          SRC_DEST_URN_PREFIX,
-          ERR_REASON_URN_PREFIX);
+          EPCIS.BIZ_STEP_URN_PREFIX,
+          EPCIS.DISPOSITION_URN_PREFIX,
+          EPCIS.BIZ_TRANSACTION_URN_PREFIX,
+          EPCIS.SRC_DEST_URN_PREFIX,
+          EPCIS.ERROR_REASON_URN_PREFIX);
   private static final List<String> CURIE_FORMATTED_CBV_STRING =
       Arrays.asList(
-          BIZ_STEP_CURIE_PREFIX,
-          DISPOSITION_CURIE_PREFIX,
-          BIZ_TRANSACTION_CURIE_PREFIX,
-          SRC_DEST_CURIE_PREFIX,
-          ERR_REASON_CURIE_PREFIX);
+          EPCIS.BIZ_STEP_CURIE_PREFIX,
+          EPCIS.DISPOSITION_CURIE_PREFIX,
+          EPCIS.BIZ_TRANSACTION_CURIE_PREFIX,
+          EPCIS.SRC_DEST_CURIE_PREFIX,
+          EPCIS.ERR_REASON_CURIE_PREFIX);
   private static final List<String> WEBURI_FORMATTED_CBV_STRING =
       Arrays.asList(
-          BIZ_STEP_WEB_URI_PREFIX,
-          DISPOSITION_WEB_URI_PREFIX,
-          BIZ_TRANSACTION_WEB_URI_PREFIX,
-          SRC_DEST_WEB_URI_PREFIX,
-          ERR_REASON_WEB_URI_PREFIX,
-          BIZ_STEP_GS1_PREFIX,
-          DISPOSITION_GS1_PREFIX,
-          BIZ_TRANSACTION_GS1_PREFIX,
-          SRC_DEST_GS1_PREFIX,
-          ERR_REASON_GS1_PREFIX);
+          EPCIS.BIZ_STEP_WEBURI_CBV_PREFIX,
+          EPCIS.DISPOSITION_WEBURI_CBV_PREFIX,
+          EPCIS.BIZ_TRANSACTION_WEBURI_CBV_PREFIX,
+          EPCIS.SRC_DEST_WEBURI_CBV_PREFIX,
+          EPCIS.ERR_REASON_WEBURI_CBV_PREFIX,
+          EPCIS.BIZ_STEP_WEBURI_VOC_PREFIX,
+          EPCIS.DISPOSITION_WEBURI_VOC_PREFIX,
+          EPCIS.BIZ_TRANSACTION_WEBURI_VOC_PREFIX,
+          EPCIS.SRC_DEST_WEBURI_VOC_PREFIX,
+          EPCIS.ERR_REASON_WEBURI_VOC_PREFIX);
 
   private static final Map<String, String> CURIE_PREFIX_MAPPER = new HashMap<>();
 
@@ -77,17 +57,20 @@ public class EventVocabularyFormatter implements VocabularyFormat {
   private static final List<String> excludeSerial = List.of("/lot/", "/ser/", "/10/", "/21/");
 
   static {
-    CURIE_PREFIX_MAPPER.put("bizstep", BIZ_STEP_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("disposition", DISPOSITION_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("persistentdisposition", DISPOSITION_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("biztransactionlist", BIZ_TRANSACTION_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("biztransaction", BIZ_TRANSACTION_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("sourcelist", SRC_DEST_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("destinationlist", SRC_DEST_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("source", SRC_DEST_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("destination", SRC_DEST_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("errordeclaration", ERR_REASON_CURIE_PREFIX);
-    CURIE_PREFIX_MAPPER.put("reason", ERR_REASON_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(EPCIS.BIZ_STEP.toLowerCase(), EPCIS.BIZ_STEP_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(EPCIS.DISPOSITION, EPCIS.DISPOSITION_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(
+        EPCIS.PERSISTENT_DISPOSITION.toLowerCase(), EPCIS.DISPOSITION_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(
+        EPCIS.BIZ_TRANSACTION_LIST.toLowerCase(), EPCIS.BIZ_TRANSACTION_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(
+        EPCIS.BIZ_TRANSACTION.toLowerCase(), EPCIS.BIZ_TRANSACTION_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(EPCIS.SOURCE_LIST.toLowerCase(), EPCIS.SRC_DEST_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(EPCIS.DESTINATION_LIST.toLowerCase(), EPCIS.SRC_DEST_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(EPCIS.SOURCE, EPCIS.SRC_DEST_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(EPCIS.DESTINATION, EPCIS.SRC_DEST_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(EPCIS.ERROR_DECLARATION.toLowerCase(), EPCIS.ERR_REASON_CURIE_PREFIX);
+    CURIE_PREFIX_MAPPER.put(EPCIS.REASON, EPCIS.ERR_REASON_CURIE_PREFIX);
 
     // Add the key value pair for the identifier
     shortNameKeyIdentifier.put("/gtin/", "/01/");
@@ -115,30 +98,30 @@ public class EventVocabularyFormatter implements VocabularyFormat {
 
     String webURI;
 
-    if (urnVocabulary.startsWith(BIZ_STEP_URN_PREFIX)) {
+    if (urnVocabulary.startsWith(EPCIS.BIZ_STEP_URN_PREFIX)) {
       // Business Step remove the urn:epcglobal:cbv:bizstep: and replace with
       // https://ns.gs1.org/voc/Bizstep-
-      webURI = BIZ_STEP_WEB_URI_PREFIX;
+      webURI = EPCIS.BIZ_STEP_WEBURI_CBV_PREFIX;
 
-    } else if (urnVocabulary.startsWith(DISPOSITION_URN_PREFIX)) {
+    } else if (urnVocabulary.startsWith(EPCIS.DISPOSITION_URN_PREFIX)) {
       // Disposition remove the urn:epcglobal:cbv:disp: and replace with
       // https://ns.gs1.org/voc/Disp-
-      webURI = DISPOSITION_WEB_URI_PREFIX;
+      webURI = EPCIS.DISPOSITION_WEBURI_CBV_PREFIX;
 
-    } else if (urnVocabulary.startsWith(BIZ_TRANSACTION_URN_PREFIX)) {
+    } else if (urnVocabulary.startsWith(EPCIS.BIZ_TRANSACTION_URN_PREFIX)) {
       // BizTransaction type remove the urn:epcglobal:cbv:btt and replace with
       // https://ns.gs1.org/voc/BTT-
-      webURI = BIZ_TRANSACTION_WEB_URI_PREFIX;
+      webURI = EPCIS.BIZ_TRANSACTION_WEBURI_CBV_PREFIX;
 
-    } else if (urnVocabulary.startsWith(SRC_DEST_URN_PREFIX)) {
+    } else if (urnVocabulary.startsWith(EPCIS.SRC_DEST_URN_PREFIX)) {
       // Source and Destination remove the urn:epcglobal:cbv:sdt: and replace with
       // https://ns.gs1.org/voc/SDT-
-      webURI = SRC_DEST_WEB_URI_PREFIX;
+      webURI = EPCIS.SRC_DEST_WEBURI_CBV_PREFIX;
 
-    } else if (urnVocabulary.startsWith(ERR_REASON_URN_PREFIX)) {
+    } else if (urnVocabulary.startsWith(EPCIS.ERROR_REASON_URN_PREFIX)) {
       // For ErrorDeclaration reason remove the urn:epcglobal:cbv:er: and replace with
       // https://ns.gs1.org/voc/ER-
-      webURI = ERR_REASON_WEB_URI_PREFIX;
+      webURI = EPCIS.ERR_REASON_WEBURI_CBV_PREFIX;
     } else {
       return urnVocabulary;
     }
@@ -150,33 +133,33 @@ public class EventVocabularyFormatter implements VocabularyFormat {
   // JSON/JSON-LD conversion to XML.
   public String canonicalString(final String webUriVocabulary) {
 
-    if (webUriVocabulary.startsWith(BIZ_STEP_WEB_URI_PREFIX)) {
+    if (webUriVocabulary.startsWith(EPCIS.BIZ_STEP_WEBURI_CBV_PREFIX)) {
       // For Business Step remove the https://ns.gs1.org/voc/Bizstep- and replace with
       // urn:epcglobal:cbv:bizstep:
-      return BIZ_STEP_URN_PREFIX
+      return EPCIS.BIZ_STEP_URN_PREFIX
           + webUriVocabulary.substring(webUriVocabulary.lastIndexOf("-") + 1);
 
-    } else if (webUriVocabulary.startsWith(DISPOSITION_WEB_URI_PREFIX)) {
+    } else if (webUriVocabulary.startsWith(EPCIS.DISPOSITION_WEBURI_CBV_PREFIX)) {
       // For Disposition remove https://ns.gs1.org/voc/Disp- and replace with
       // urn:epcglobal:cbv:disp:
-      return DISPOSITION_URN_PREFIX
+      return EPCIS.DISPOSITION_URN_PREFIX
           + webUriVocabulary.substring(webUriVocabulary.lastIndexOf("-") + 1);
 
-    } else if (webUriVocabulary.startsWith(BIZ_TRANSACTION_WEB_URI_PREFIX)) {
+    } else if (webUriVocabulary.startsWith(EPCIS.BIZ_TRANSACTION_WEBURI_CBV_PREFIX)) {
       // For Business Transaction remove https://ns.gs1.org/voc/BTT- and replace with
       // urn:epcglobal:cbv:btt:
-      return BIZ_TRANSACTION_URN_PREFIX
+      return EPCIS.BIZ_TRANSACTION_URN_PREFIX
           + webUriVocabulary.substring(webUriVocabulary.lastIndexOf("-") + 1);
 
-    } else if (webUriVocabulary.startsWith(SRC_DEST_WEB_URI_PREFIX)) {
+    } else if (webUriVocabulary.startsWith(EPCIS.SRC_DEST_WEBURI_CBV_PREFIX)) {
       // For Source/Destination remove prefix https://ns.gs1.org/voc/SDT- and replace with
       // urn:epcglobal:cbv:sdt:
-      return SRC_DEST_URN_PREFIX
+      return EPCIS.SRC_DEST_URN_PREFIX
           + webUriVocabulary.substring(webUriVocabulary.lastIndexOf("-") + 1);
 
-    } else if (webUriVocabulary.startsWith(ERR_REASON_WEB_URI_PREFIX)) {
+    } else if (webUriVocabulary.startsWith(EPCIS.ERR_REASON_WEBURI_CBV_PREFIX)) {
       // For Error Reason remove https://ns.gs1.org/voc/ER- and replace with urn:epcglobal:cbv:er:
-      return ERR_REASON_URN_PREFIX
+      return EPCIS.ERROR_REASON_URN_PREFIX
           + webUriVocabulary.substring(webUriVocabulary.lastIndexOf("-") + 1);
     }
 
@@ -214,39 +197,39 @@ public class EventVocabularyFormatter implements VocabularyFormat {
       case "bizstep":
         // Convert BareString bizStep into CBV formatted URN/WebURI bizStep
         prefix =
-            format.equalsIgnoreCase(WEBURI_FORMATTED)
-                ? BIZ_STEP_WEB_URI_PREFIX
-                : BIZ_STEP_URN_PREFIX;
+            format.equalsIgnoreCase(WEBURI)
+                ? EPCIS.BIZ_STEP_WEBURI_CBV_PREFIX
+                : EPCIS.BIZ_STEP_URN_PREFIX;
         break;
       case "disposition", "persistentdisposition":
         // Convert BareString Disposition/PersistentDisposition into CBV formatted URN/WebURI
         prefix =
-            format.equalsIgnoreCase(WEBURI_FORMATTED)
-                ? DISPOSITION_WEB_URI_PREFIX
-                : DISPOSITION_URN_PREFIX;
+            format.equalsIgnoreCase(WEBURI)
+                ? EPCIS.DISPOSITION_WEBURI_CBV_PREFIX
+                : EPCIS.DISPOSITION_URN_PREFIX;
         break;
       case "biztransactionlist", "biztransaction":
         // Convert BareString bizTransaction type into CBV formatted URN/WebURI bizTransaction
         prefix =
-            format.equalsIgnoreCase(WEBURI_FORMATTED)
-                ? BIZ_TRANSACTION_WEB_URI_PREFIX
-                : BIZ_TRANSACTION_URN_PREFIX;
+            format.equalsIgnoreCase(WEBURI)
+                ? EPCIS.BIZ_TRANSACTION_WEBURI_CBV_PREFIX
+                : EPCIS.BIZ_TRANSACTION_URN_PREFIX;
         break;
       case "sourcelist", "destinationlist", "source", "destination":
         // Convert BareString Source/Destination type into CBV formatted URN/WebURI
         // Source/Destination
         prefix =
-            format.equalsIgnoreCase(WEBURI_FORMATTED)
-                ? SRC_DEST_WEB_URI_PREFIX
-                : SRC_DEST_URN_PREFIX;
+            format.equalsIgnoreCase(WEBURI)
+                ? EPCIS.SRC_DEST_WEBURI_CBV_PREFIX
+                : EPCIS.SRC_DEST_URN_PREFIX;
         break;
       case "errordeclaration", "reason":
         // Convert BareString ErrorDeclaration Reason into CBV formatted URN/WebURI ErrorDeclaration
         // Reason
         prefix =
-            format.equalsIgnoreCase(WEBURI_FORMATTED)
-                ? ERR_REASON_WEB_URI_PREFIX
-                : ERR_REASON_URN_PREFIX;
+            format.equalsIgnoreCase(WEBURI)
+                ? EPCIS.ERR_REASON_WEBURI_CBV_PREFIX
+                : EPCIS.ERROR_REASON_URN_PREFIX;
         break;
       default:
         return bareString;
@@ -281,17 +264,17 @@ public class EventVocabularyFormatter implements VocabularyFormat {
           gs1Identifier =
               gs1Identifier.replace(
                   gs1Identifier.substring(0, gs1Identifier.indexOf(entry.getKey())),
-                  Constants.GS1_IDENTIFIER_DOMAIN);
+                  EPCIS.GS1_IDENTIFIER_DOMAIN);
         }
         gs1Identifier = gs1Identifier.replace(entry.getKey(), entry.getValue());
       } else if (gs1Identifier.contains(entry.getValue())
           && (!excludeSerial.contains(entry.getValue()))
-          && !gs1Identifier.startsWith(Constants.GS1_IDENTIFIER_DOMAIN)) {
+          && !gs1Identifier.startsWith(EPCIS.GS1_IDENTIFIER_DOMAIN)) {
         // If the identifier key is already present then only replace the domain to GS1
         gs1Identifier =
             gs1Identifier.replace(
                 gs1Identifier.substring(0, gs1Identifier.indexOf(entry.getValue())),
-                Constants.GS1_IDENTIFIER_DOMAIN);
+                EPCIS.GS1_IDENTIFIER_DOMAIN);
       }
     }
     return gs1Identifier;

--- a/src/main/java/io/openepcis/epc/translator/constants/ConstantDigitalLinkTranslatorInfo.java
+++ b/src/main/java/io/openepcis/epc/translator/constants/ConstantDigitalLinkTranslatorInfo.java
@@ -19,16 +19,10 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class Constants {
-  public static final String GS1_IDENTIFIER_DOMAIN = "https://id.gs1.org";
-  public static final String GS1_CBV_DOMAIN = "https://ref.gs1.org/cbv/";
-  public static final String GS1_VOC_DOMAIN = "https://gs1.org/voc/";
-  public static final String GS1_URN_CBV_PREFIX = "urn:epcglobal:cbv:";
-
+public class ConstantDigitalLinkTranslatorInfo {
   public static final String AS_CAPTURED = "asCaptured";
   public static final String CANONICAL_DL = "canonicalDL";
   public static final String AS_URN = "asURN";
   public static final String SERIAL = "serial";
   public static final String GCP_LENGTH = " GCP Length : ";
-  public static final String WEBURI_FORMATTED = "WebURI";
 }

--- a/src/main/java/io/openepcis/epc/translator/constants/StandardVocabElements.java
+++ b/src/main/java/io/openepcis/epc/translator/constants/StandardVocabElements.java
@@ -15,16 +15,21 @@
  */
 package io.openepcis.epc.translator.constants;
 
+import static io.openepcis.constants.EPCIS.GS1_CBV_DOMAIN;
+import static io.openepcis.constants.EPCIS.GS1_VOC_DOMAIN;
+
+import io.openepcis.constants.EPCIS;
 import io.openepcis.epc.translator.exception.ValidationException;
 
 public enum StandardVocabElements {
-  BIZ_STEP("urn:epcglobal:cbv:bizstep:", Constants.GS1_CBV_DOMAIN + "Bizstep-"),
-  DISPOSITION("urn:epcglobal:cbv:disp:", Constants.GS1_CBV_DOMAIN + "Disp-"),
-  BIZ_TRANSACTION_TYPE("urn:epcglobal:cbv:btt:", Constants.GS1_CBV_DOMAIN + "BTT-"),
-  SOURCE_DEST_TYPE("urn:epcglobal:cbv:sdt:", Constants.GS1_CBV_DOMAIN + "SDT-"),
-  ERROR_REASON("urn:epcglobal:cbv:er:", Constants.GS1_CBV_DOMAIN + "ER-"),
-  MEASUREMENT_TYPE("gs1:", Constants.GS1_VOC_DOMAIN),
-  ALERT_TYPE("gs1:", Constants.GS1_VOC_DOMAIN);
+  BIZ_STEP(EPCIS.BIZ_STEP_URN_PREFIX, GS1_CBV_DOMAIN + EPCIS.BIZ_STEP_WEBURI_PREFIX),
+  DISPOSITION(EPCIS.DISPOSITION_URN_PREFIX, GS1_CBV_DOMAIN + EPCIS.DISP_WEBURI_PREFIX),
+  BIZ_TRANSACTION_TYPE(
+      EPCIS.BIZ_TRANSACTION_URN_PREFIX, GS1_CBV_DOMAIN + EPCIS.BIZ_TRANSACTION_WEBURI_PREFIX),
+  SOURCE_DEST_TYPE(EPCIS.SRC_DEST_URN_PREFIX, GS1_CBV_DOMAIN + EPCIS.SRC_DEST_WEBURI_PREFIX),
+  ERROR_REASON(EPCIS.ERROR_REASON_URN_PREFIX, GS1_CBV_DOMAIN + EPCIS.ERROR_REASON_WEBURI_PREFIX),
+  MEASUREMENT_TYPE(EPCIS.GS1_PREFIX, GS1_VOC_DOMAIN),
+  ALERT_TYPE(EPCIS.GS1_PREFIX, GS1_VOC_DOMAIN);
 
   private final String urnPrefix;
   private final String dlPrefix;

--- a/src/main/java/io/openepcis/epc/translator/converter/CPIConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/CPIConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.CPIValidator;
 import java.util.HashMap;
@@ -66,14 +68,10 @@ public class CPIConverter implements Converter {
       final String cpi =
           gcp + urn.substring(urn.indexOf(".") + 1, urn.indexOf(".", urn.indexOf(".") + 1));
       if (isClassLevel) {
-        return Constants.GS1_IDENTIFIER_DOMAIN + CPI_URI_PART + cpi;
+        return GS1_IDENTIFIER_DOMAIN + CPI_URI_PART + cpi;
       } else {
         final String serialNumber = urn.substring(urn.lastIndexOf(".") + 1);
-        return Constants.GS1_IDENTIFIER_DOMAIN
-            + CPI_URI_PART
-            + cpi
-            + CPI_SERIAL_PART
-            + serialNumber;
+        return GS1_IDENTIFIER_DOMAIN + CPI_URI_PART + cpi + CPI_SERIAL_PART + serialNumber;
       }
     } catch (Exception exception) {
       throw new ValidationException(
@@ -111,7 +109,7 @@ public class CPIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of CPI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -140,28 +138,27 @@ public class CPIConverter implements Converter {
                 + cpi.substring(gcpLength)
                 + "."
                 + serial;
-        buildURN.put(Constants.SERIAL, serial);
+        buildURN.put(SERIAL, serial);
       }
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(CPI_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(CPI_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("cpi", cpi);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the CPI identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -206,7 +203,7 @@ public class CPIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of CPI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/GCNConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/GCNConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.GCNValidator;
 import java.util.HashMap;
@@ -64,7 +66,7 @@ public class GCNConverter implements Converter {
       if (!isClassLevel) {
         sgcn = sgcn + urn.substring(urn.indexOf(".", urn.indexOf(".") + 1) + 1);
       }
-      return Constants.GS1_IDENTIFIER_DOMAIN + GCN_URI_PART + sgcn;
+      return GS1_IDENTIFIER_DOMAIN + GCN_URI_PART + sgcn;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of GCN identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -92,7 +94,7 @@ public class GCNConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GCN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -115,28 +117,27 @@ public class GCNConverter implements Converter {
       } else {
         final String serial = sgcn.substring(13);
         asURN = "urn:epc:id:sgcn:" + tempSgcn + "." + serial;
-        buildURN.put(Constants.SERIAL, serial);
+        buildURN.put(SERIAL, serial);
       }
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(GCN_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(GCN_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("sgcn", sgcn);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the GCN identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -172,7 +173,7 @@ public class GCNConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GCN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/GDTIConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/GDTIConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.GDTIValidator;
 import java.util.HashMap;
@@ -67,7 +69,7 @@ public class GDTIConverter implements Converter {
       if (!isClassLevel) {
         gdti = gdti + urn.substring(urn.indexOf(".", urn.indexOf(".") + 1) + 1);
       }
-      return Constants.GS1_IDENTIFIER_DOMAIN + GDTI_URI_PART + gdti;
+      return GS1_IDENTIFIER_DOMAIN + GDTI_URI_PART + gdti;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of GDTI identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -100,7 +102,7 @@ public class GDTIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GDTI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -122,28 +124,27 @@ public class GDTIConverter implements Converter {
             dlURI.substring(dlURI.indexOf(GDTI_URI_PART) + GDTI_URI_PART.length() + 13);
         asURN =
             "urn:epc:id:gdti:" + gdti.substring(0, gcpLength) + "." + gdtiSubString + "." + serial;
-        buildURN.put(Constants.SERIAL, serial);
+        buildURN.put(SERIAL, serial);
       }
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(GDTI_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(GDTI_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("gdti", gdti);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the GDTI identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -189,7 +190,7 @@ public class GDTIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GDTI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/GIAIConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/GIAIConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.GIAIValidator;
 import java.util.HashMap;
@@ -49,7 +51,7 @@ public class GIAIConverter implements Converter {
       final String gcp =
           urn.substring(urn.indexOf(GIAI_URN_PART) + GIAI_URN_PART.length(), urn.indexOf('.'));
       final String giai = gcp + urn.substring(urn.indexOf('.') + 1);
-      return Constants.GS1_IDENTIFIER_DOMAIN + GIAI_URI_PART + giai;
+      return GS1_IDENTIFIER_DOMAIN + GIAI_URI_PART + giai;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of GIAI identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -73,7 +75,7 @@ public class GIAIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GIAI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -88,24 +90,23 @@ public class GIAIConverter implements Converter {
       asURN = "urn:epc:id:giai:" + giai.substring(0, gcpLength) + "." + giai.substring(gcpLength);
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(GIAI_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(GIAI_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("giai", giai);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the GIAI identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -136,7 +137,7 @@ public class GIAIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GIAI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/GINCConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/GINCConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.GINCValidator;
 import java.util.HashMap;
@@ -48,7 +50,7 @@ public class GINCConverter implements Converter {
       String ginc =
           urn.substring(urn.indexOf(GINC_URN_PART) + GINC_URN_PART.length(), urn.indexOf("."));
       ginc = ginc + urn.substring(urn.indexOf(".") + 1);
-      return Constants.GS1_IDENTIFIER_DOMAIN + GINC_URI_PART + ginc;
+      return GS1_IDENTIFIER_DOMAIN + GINC_URI_PART + ginc;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of GINC identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -72,7 +74,7 @@ public class GINCConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GINC identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -87,24 +89,23 @@ public class GINCConverter implements Converter {
       asURN = "urn:epc:id:ginc:" + ginc.substring(0, gcpLength) + "." + ginc.substring(gcpLength);
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(GINC_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(GINC_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("ginc", ginc);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the GINC identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -132,7 +133,7 @@ public class GINCConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GINC identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/GRAIConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/GRAIConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.GRAIValidator;
 import java.util.HashMap;
@@ -64,10 +66,10 @@ public class GRAIConverter implements Converter {
       grai = grai.substring(0, 12) + UPCEANLogicImpl.calcChecksum(grai.substring(0, 12));
 
       if (isClassLevel) {
-        return Constants.GS1_IDENTIFIER_DOMAIN + GRAI_URI_PART + grai;
+        return GS1_IDENTIFIER_DOMAIN + GRAI_URI_PART + grai;
       } else {
         final String serialNumber = urn.substring(urn.indexOf(".", urn.indexOf(".") + 1) + 1);
-        return Constants.GS1_IDENTIFIER_DOMAIN + GRAI_URI_PART + grai + serialNumber;
+        return GS1_IDENTIFIER_DOMAIN + GRAI_URI_PART + grai + serialNumber;
       }
     } catch (Exception exception) {
       throw new ValidationException(
@@ -99,7 +101,7 @@ public class GRAIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GRAI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -124,24 +126,23 @@ public class GRAIConverter implements Converter {
       }
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(GRAI_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(GRAI_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("grai", grai);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the GRAI identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -187,7 +188,7 @@ public class GRAIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GRAI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/GSINConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/GSINConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.GSINValidator;
 import java.util.HashMap;
@@ -50,7 +52,7 @@ public class GSINConverter implements Converter {
           urn.substring(urn.indexOf(GSIN_URN_PART) + GSIN_URN_PART.length(), urn.indexOf("."))
               + urn.substring(urn.indexOf(".") + 1);
       gsin = gsin.substring(0, 16) + UPCEANLogicImpl.calcChecksum(gsin.substring(0, 16));
-      return Constants.GS1_IDENTIFIER_DOMAIN + GSIN_URI_PART + gsin;
+      return GS1_IDENTIFIER_DOMAIN + GSIN_URI_PART + gsin;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of GSIN identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -74,7 +76,7 @@ public class GSINConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GSIN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -94,24 +96,23 @@ public class GSINConverter implements Converter {
               + gsin.substring(gcpLength, gsin.length() - 1);
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(GSIN_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(GSIN_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("gsin", gsin);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the GSIN identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -139,7 +140,7 @@ public class GSINConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GSIN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/GSRNConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/GSRNConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.GSRNValidator;
 import java.util.HashMap;
@@ -48,7 +50,7 @@ public class GSRNConverter implements Converter {
       final String gcp = urn.substring(urn.lastIndexOf(":") + 1, urn.indexOf('.'));
       String gsrn = gcp + urn.substring(urn.indexOf('.') + 1);
       gsrn = gsrn.substring(0, 17) + UPCEANLogicImpl.calcChecksum(gsrn.substring(0, 17));
-      return Constants.GS1_IDENTIFIER_DOMAIN + GSRN_URI_PART + gsrn;
+      return GS1_IDENTIFIER_DOMAIN + GSRN_URI_PART + gsrn;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of GSRN identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -72,7 +74,7 @@ public class GSRNConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GSRN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -91,24 +93,23 @@ public class GSRNConverter implements Converter {
               + gsrn.substring(gcpLength, gsrn.length() - 1);
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(GSRN_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(GSRN_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("gsrn", gsrn);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the GSRN identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -136,7 +137,7 @@ public class GSRNConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GSRN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/GSRNPConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/GSRNPConverter.java
@@ -15,8 +15,11 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
+import io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.GSRNPValidator;
 import java.util.HashMap;
@@ -48,7 +51,7 @@ public class GSRNPConverter implements Converter {
       final String gcp = urn.substring(urn.lastIndexOf(":") + 1, urn.indexOf('.'));
       String gsrnp = gcp + urn.substring(urn.indexOf('.') + 1);
       gsrnp = gsrnp.substring(0, 17) + UPCEANLogicImpl.calcChecksum(gsrnp.substring(0, 17));
-      return Constants.GS1_IDENTIFIER_DOMAIN + GSRNP_URI_PART + gsrnp;
+      return GS1_IDENTIFIER_DOMAIN + GSRNP_URI_PART + gsrnp;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of GSRNP identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -72,7 +75,7 @@ public class GSRNPConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GSRNP identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + ConstantDigitalLinkTranslatorInfo.GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -91,24 +94,23 @@ public class GSRNPConverter implements Converter {
               + gsrnp.substring(gcpLength, gsrnp.length() - 1);
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(GSRNP_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(GSRNP_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("gsrnp", gsrnp);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the GSRNP identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -136,7 +138,7 @@ public class GSRNPConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of GSRNP identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/ITIPConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/ITIPConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.ITIPValidator;
 import java.util.HashMap;
@@ -88,14 +90,10 @@ public class ITIPConverter implements Converter {
               + itip.substring(13);
 
       if (isClassLevel) {
-        return Constants.GS1_IDENTIFIER_DOMAIN + ITIP_URI_PART + itip;
+        return GS1_IDENTIFIER_DOMAIN + ITIP_URI_PART + itip;
       } else {
         final String serialNumber = urn.substring(StringUtils.ordinalIndexOf(urn, ".", 4) + 1);
-        return Constants.GS1_IDENTIFIER_DOMAIN
-            + ITIP_URI_PART
-            + itip
-            + ITIP_SERIAL_PART
-            + serialNumber;
+        return GS1_IDENTIFIER_DOMAIN + ITIP_URI_PART + itip + ITIP_SERIAL_PART + serialNumber;
       }
     } catch (Exception exception) {
       throw new ValidationException(
@@ -132,7 +130,7 @@ public class ITIPConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of ITIP identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -167,28 +165,27 @@ public class ITIPConverter implements Converter {
                 + itip.substring(16, 18)
                 + "."
                 + serial;
-        buildURN.put(Constants.SERIAL, serial);
+        buildURN.put(SERIAL, serial);
       }
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(ITIP_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(ITIP_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("itip", itip);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the ITIP identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -234,7 +231,7 @@ public class ITIPConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of ITIP identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/LGTINConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/LGTINConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.LGTINValidator;
 import java.util.HashMap;
@@ -56,11 +58,7 @@ public class LGTINConverter implements Converter {
           gcp + urn.substring(urn.indexOf('.') + 2, urn.indexOf(".", urn.indexOf(".") + 1));
       lgtin = lgtin.substring(0, 13) + UPCEANLogicImpl.calcChecksum(lgtin.substring(0, 13));
       final String serialNumber = urn.substring(urn.indexOf(".", urn.indexOf(".") + 1) + 1);
-      return Constants.GS1_IDENTIFIER_DOMAIN
-          + LGTIN_URI_PART
-          + lgtin
-          + LGTIN_SERIAL_PART
-          + serialNumber;
+      return GS1_IDENTIFIER_DOMAIN + LGTIN_URI_PART + lgtin + LGTIN_SERIAL_PART + serialNumber;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of LGTIN identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -87,7 +85,7 @@ public class LGTINConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of LGTIN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -111,25 +109,24 @@ public class LGTINConverter implements Converter {
               + serial;
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(LGTIN_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(LGTIN_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("lgtin", lgtin);
-      buildURN.put(Constants.SERIAL, serial);
+      buildURN.put(SERIAL, serial);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the LGTIN identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -161,7 +158,7 @@ public class LGTINConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of LGTIN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/PGLNConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/PGLNConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.PGLNValidator;
 import java.util.HashMap;
@@ -48,7 +50,7 @@ public class PGLNConverter implements Converter {
       final String gcp = urn.substring(urn.lastIndexOf(":") + 1, urn.indexOf("."));
       String pgln = gcp + urn.substring(urn.indexOf(".") + 1);
       pgln = pgln.substring(0, 12) + UPCEANLogicImpl.calcChecksum(pgln.substring(0, 12));
-      return Constants.GS1_IDENTIFIER_DOMAIN + PGLN_URI_PART + pgln;
+      return GS1_IDENTIFIER_DOMAIN + PGLN_URI_PART + pgln;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of PGLN identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -72,7 +74,7 @@ public class PGLNConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of PGLN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -91,24 +93,23 @@ public class PGLNConverter implements Converter {
               + pgln.substring(gcpLength, pgln.length() - 1);
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(PGLN_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(PGLN_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("pgln", pgln);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the PGLN identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -136,7 +137,7 @@ public class PGLNConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of PGLN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/SGLNConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/SGLNConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.SGLNValidator;
 import java.util.HashMap;
@@ -61,10 +63,10 @@ public class SGLNConverter implements Converter {
       final String serial = urn.substring(StringUtils.ordinalIndexOf(urn, ".", 2) + 1);
 
       if (serial.length() == 0) {
-        return Constants.GS1_IDENTIFIER_DOMAIN + SGLN_URI_PART + sgln;
+        return GS1_IDENTIFIER_DOMAIN + SGLN_URI_PART + sgln;
       } else {
         // Add serial part if not 0
-        return Constants.GS1_IDENTIFIER_DOMAIN
+        return GS1_IDENTIFIER_DOMAIN
             + SGLN_URI_PART
             + sgln
             + ((!serial.equals("0")) ? SGLN_SERIAL_PART + serial : "");
@@ -91,7 +93,7 @@ public class SGLNConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of SGLN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -131,24 +133,23 @@ public class SGLNConverter implements Converter {
       }
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(SGLN_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(SGLN_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("sgln", sgln);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the SGLN identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -186,7 +187,7 @@ public class SGLNConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of SGLN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/SGTINConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/SGTINConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.SGTINValidator;
 import java.util.HashMap;
@@ -73,15 +75,10 @@ public class SGTINConverter implements Converter {
       sgtin = sgtin.substring(0, 13) + UPCEANLogicImpl.calcChecksum(sgtin.substring(0, 13));
 
       if (isClassLevel) {
-        sgtin = Constants.GS1_IDENTIFIER_DOMAIN + SGTIN_URI_PART + sgtin;
+        sgtin = GS1_IDENTIFIER_DOMAIN + SGTIN_URI_PART + sgtin;
       } else {
         final String serialNumber = urn.substring(urn.indexOf(".", urn.indexOf(".") + 1) + 1);
-        sgtin =
-            Constants.GS1_IDENTIFIER_DOMAIN
-                + SGTIN_URI_PART
-                + sgtin
-                + SGTIN_SERIAL_PART
-                + serialNumber;
+        sgtin = GS1_IDENTIFIER_DOMAIN + SGTIN_URI_PART + sgtin + SGTIN_SERIAL_PART + serialNumber;
       }
       return sgtin;
     } catch (Exception exception) {
@@ -116,7 +113,7 @@ public class SGTINConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of SGTIN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -141,28 +138,27 @@ public class SGTINConverter implements Converter {
         final String serial =
             dlURI.substring(dlURI.indexOf(SGTIN_SERIAL_PART) + SGTIN_SERIAL_PART.length());
         asURN = "urn:epc:id:sgtin:" + sgtinUrn + "." + serial;
-        buildURN.put(Constants.SERIAL, serial);
+        buildURN.put(SERIAL, serial);
       }
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(SGTIN_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(SGTIN_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("gtin", sgtin);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the SGTIN identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -207,7 +203,7 @@ public class SGTINConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of SGTIN identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/SSCCConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/SSCCConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.SSCCValidator;
 import java.util.HashMap;
@@ -49,7 +51,7 @@ public class SSCCConverter implements Converter {
               + urn.substring(urn.lastIndexOf(":") + 1, urn.indexOf('.'));
       String sscc = gcp + urn.substring(urn.indexOf('.') + 2);
       sscc = sscc.substring(0, 17) + UPCEANLogicImpl.calcChecksum(sscc.substring(0, 17));
-      sscc = Constants.GS1_IDENTIFIER_DOMAIN + SSCC_URI_PART + sscc;
+      sscc = GS1_IDENTIFIER_DOMAIN + SSCC_URI_PART + sscc;
       return sscc;
     } catch (Exception exception) {
       throw new ValidationException(
@@ -73,7 +75,7 @@ public class SSCCConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of SSCC identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -94,18 +96,17 @@ public class SSCCConverter implements Converter {
       asURN = "urn:epc:id:sscc:" + ssccURN;
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(SSCC_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(SSCC_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("sscc", sscc);
     } catch (Exception exception) {
       throw new ValidationException(
@@ -136,7 +137,7 @@ public class SSCCConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of SSCC identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());

--- a/src/main/java/io/openepcis/epc/translator/converter/UPUIConverter.java
+++ b/src/main/java/io/openepcis/epc/translator/converter/UPUIConverter.java
@@ -15,8 +15,10 @@
  */
 package io.openepcis.epc.translator.converter;
 
+import static io.openepcis.constants.EPCIS.GS1_IDENTIFIER_DOMAIN;
+import static io.openepcis.epc.translator.constants.ConstantDigitalLinkTranslatorInfo.*;
+
 import io.openepcis.epc.translator.DefaultGCPLengthProvider;
-import io.openepcis.epc.translator.constants.Constants;
 import io.openepcis.epc.translator.exception.ValidationException;
 import io.openepcis.epc.translator.validation.UPUIValidator;
 import java.util.HashMap;
@@ -61,11 +63,7 @@ public class UPUIConverter implements Converter {
                   StringUtils.ordinalIndexOf(urn, ".", 2));
       upui = upui + UPCEANLogicImpl.calcChecksum(upui);
       final String serialNumber = urn.substring(StringUtils.ordinalIndexOf(urn, ".", 2) + 1);
-      return Constants.GS1_IDENTIFIER_DOMAIN
-          + UPUI_URI_PART
-          + upui
-          + UPUI_SERIAL_PART
-          + serialNumber;
+      return GS1_IDENTIFIER_DOMAIN + UPUI_URI_PART + upui + UPUI_SERIAL_PART + serialNumber;
     } catch (Exception exception) {
       throw new ValidationException(
           "Exception occurred during the conversion of UPUI identifier from URN to digital link WebURI,\nPlease check the provided identifier : "
@@ -92,7 +90,7 @@ public class UPUIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of UPUI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());
@@ -113,20 +111,19 @@ public class UPUIConverter implements Converter {
       asURN = "urn:epc:id:upui:" + upui + "." + serial;
 
       // If dlURI contains GS1 domain then captured and canonical are same
-      if (dlURI.contains(Constants.GS1_IDENTIFIER_DOMAIN)) {
-        buildURN.put(Constants.CANONICAL_DL, dlURI);
+      if (dlURI.contains(GS1_IDENTIFIER_DOMAIN)) {
+        buildURN.put(CANONICAL_DL, dlURI);
       } else {
         // If dlURI does not contain GS1 domain then canonicalDL is based on GS1 domain
         final String canonicalDL =
-            dlURI.replace(
-                dlURI.substring(0, dlURI.indexOf(UPUI_URI_PART)), Constants.GS1_IDENTIFIER_DOMAIN);
-        buildURN.put(Constants.CANONICAL_DL, canonicalDL);
+            dlURI.replace(dlURI.substring(0, dlURI.indexOf(UPUI_URI_PART)), GS1_IDENTIFIER_DOMAIN);
+        buildURN.put(CANONICAL_DL, canonicalDL);
       }
 
-      buildURN.put(Constants.AS_CAPTURED, dlURI);
-      buildURN.put(Constants.AS_URN, asURN);
+      buildURN.put(AS_CAPTURED, dlURI);
+      buildURN.put(AS_URN, asURN);
       buildURN.put("upui", upui);
-      buildURN.put(Constants.SERIAL, serial);
+      buildURN.put(SERIAL, serial);
     } catch (Exception exception) {
       throw new ValidationException(
           "The conversion of the UPUI identifier from digital link WebURI to URN when creating the URN map encountered an error,\nPlease check the provided identifier : "
@@ -161,7 +158,7 @@ public class UPUIConverter implements Converter {
       throw new ValidationException(
           "Exception occurred during the conversion of UPUI identifier from digital link WebURI to URN,\nPlease check the provided identifier : "
               + dlURI
-              + Constants.GCP_LENGTH
+              + GCP_LENGTH
               + gcpLength
               + "\n"
               + exception.getMessage());


### PR DESCRIPTION
This project was previously using the constant information from its own project. Now that we have the central openepcis-epcis-constants project, we have added the dependency to this and used variables from there. Kindly request you to review and approve the PR.