### PR TITLE
GEN-216: option to config the gcpLength during the run time to avoid getting invalid GCP Length from GS1 default table

### DIFF
--- a/src/main/java/io/openepcis/epc/translator/DefaultGCPLengthProvider.java
+++ b/src/main/java/io/openepcis/epc/translator/DefaultGCPLengthProvider.java
@@ -74,35 +74,43 @@ public class DefaultGCPLengthProvider implements GCPLengthProvider {
   /**
    * Method to loop over the Map to find the matching id and its associated GCP Length
    *
-   * @param gs1DigitalLinkURI The digital link WebURI for which the GCP length needed ex:
-   *     https://id.gs1.org/01/12345678901231/21/9999
-   * @param gs1DigitalLinkURIIdentifier The identifier after stripping all GS1 standard prefixes'
-   *     ex: 12345678901231
+   * @param gs1DigitalLinkURI The digital link WebURI for which the GCP length needed ex:https://id.gs1.org/01/12345678901231/21/9999
+   * @param gs1DigitalLinkURIIdentifier The identifier after stripping all GS1 standard prefixes' ex: 12345678901231
    * @return returns the GCP length if found matching value in Map else returns 7 as GCP Length
    */
-  public int getGcpLength(
-      final String gs1DigitalLinkURI,
-      String gs1DigitalLinkURIIdentifier,
-      final String gs1IdentifierPrefix) {
-
+  public int getGcpLength(final String gs1DigitalLinkURI, String gs1DigitalLinkURIIdentifier, final String gs1IdentifierPrefix) {
     // Check if identifier is not matching with keyStarts-map elements
-    if (!keyStartsWithGCP.contains(gs1IdentifierPrefix)
-        && gs1DigitalLinkURIIdentifier.length() > 13) {
+    if (!keyStartsWithGCP.contains(gs1IdentifierPrefix) && gs1DigitalLinkURIIdentifier.length() > 13) {
       // For GTIN related identifiers consider from 2nd digit for finding gcp length
       gs1DigitalLinkURIIdentifier = gs1DigitalLinkURIIdentifier.substring(1);
     }
 
-    // Loop over the sorted values to find the matching GCP and its GCP Length
-    for (final Map.Entry<String, Integer> e : sortedGcpLengthList.entrySet()) {
-      if (gs1DigitalLinkURIIdentifier.startsWith(e.getKey())) {
-        return e.getValue();
+    // Make gs1DigitalLinkURIIdentifier effectively final by re-assigning to a new final variable
+    final String finalGs1DigitalLinkURIIdentifier = gs1DigitalLinkURIIdentifier;
+
+    // Loop over the sorted values to find the matching GCP and its GCP Length else default to 0
+    int gcpLength = sortedGcpLengthList.entrySet().stream()
+            .filter(entry -> finalGs1DigitalLinkURIIdentifier.startsWith(entry.getKey()))
+            .map(Map.Entry::getValue)
+            .findFirst()
+            .orElse(0);
+
+    // Return the found GCP length if not 0 else fallback to default if set or throw exception
+    if(gcpLength != 0) {
+      return gcpLength;
+    } else {
+      // Retrieve default GCP Length from system property
+      final String gcpLengthStr = System.getProperty(getClass().getName() + ".defaultGcpLength", null);
+      if(gcpLengthStr != null) {
+          try {
+              return Integer.parseInt(gcpLengthStr);
+          } catch (NumberFormatException e) {
+              throw new IllegalArgumentException("Invalid default GCP length value: " + gcpLengthStr, e);
+          }
       }
+      throw new UnsupportedGS1IdentifierException("GCP Length not found for Digital link URI : " + gs1DigitalLinkURI + ". \nVisit GEPIR (https://gepir.gs1.org/) or contact GS1 MO.");
     }
-    throw new UnsupportedGS1IdentifierException(
-        "Could not find matching GCP Length for provided GS1 Digital link URI : "
-            + gs1DigitalLinkURI
-            + "\nTry GEPIR (https://gepir.gs1.org/) or contact local GS1 MO.");
-  }
+ }
 
   /**
    * Static method to create instance of Singleton class


### PR DESCRIPTION
@sboeckelmann 

This PR will add an option to set the default GCP length during the runtime if not found in the GS1 table. Avoiding the exception for randomly created GS1 AI.

Kindly request you to review the PR and approve the changes.