### PR TITLE
GEN-448: integrate verified by gs1 service  before defaulting to 9 

### DIFF
--- a/utils/src/main/java/io/openepcis/digitallink/utils/DefaultGCPLengthProvider.java
+++ b/utils/src/main/java/io/openepcis/digitallink/utils/DefaultGCPLengthProvider.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.openepcis.core.exception.UnsupportedGS1IdentifierException;
 import io.openepcis.core.exception.UrnDLTransformationException;
+import io.openepcis.digitallink.utils.resolver.GCPLengthResolverManager;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
@@ -31,169 +32,163 @@ import java.util.regex.Pattern;
 @Slf4j
 public final class DefaultGCPLengthProvider implements GCPLengthProvider {
 
-  /* ------------------------------------------------------------------ *
-   *  Static initialisation                                              *
-   * ------------------------------------------------------------------ */
+    /* ------------------------------------------------------------------ *
+     *  Static initialisation                                              *
+     * ------------------------------------------------------------------ */
 
-  private static final String RESOURCE = "/gcpprefixformatlist.json";
-  private static final String CUSTOM_RESOURCE = "/gcpprefixformatlist-custom.json";
-  private static final String NO_GCP_HINT =
-          "Visit GEPIR (https://gepir.gs1.org/) or contact your GS1 MO.";
+    private static final String RESOURCE = "/gcpprefixformatlist.json";
+    private static final String CUSTOM_RESOURCE = "/gcpprefixformatlist-custom.json";
+    private static final String NO_GCP_HINT = "Visit GEPIR (https://gepir.gs1.org/) or contact your GS1 MO.";
 
-  /** Identifiers whose full value is already a GCP. */
-  private static final Set<String> PREFIXES_WITH_GCP = Set.of(
-          "/8010/", "/255/", "/253/", "/8004/", "/401/", "/402/",
-          "/8018/", "/8017/", "/417/", "/414/"
-  );
+    /**
+     * Identifiers whose full value is already a GCP.
+     */
+    private static final Set<String> PREFIXES_WITH_GCP = Set.of("/8010/", "/255/", "/253/", "/8004/", "/401/", "/402/", "/8018/", "/8017/", "/417/", "/414/");
 
-  /**
-   * Immutable list sorted by <em>longest prefix first</em> for fast
-   * longest-match scanning.
-   */
-  private static final List<Entry> PREFIX_ENTRIES;
+    /**
+     * Immutable list sorted by <em>longest prefix first</em> for fast
+     * longest-match scanning.
+     */
+    private static final List<Entry> PREFIX_ENTRIES;
 
-  static {
-    log.info("Loading {}", RESOURCE);
-    PREFIX_ENTRIES = loadPrefixEntries();
-    log.info("Loaded {} GCP prefixes", PREFIX_ENTRIES.size());
-  }
-
-  private static List<Entry> loadPrefixEntries() {
-    final List<Entry> list = loadFromResource(RESOURCE, true);
-
-    // Merge custom overlay entries if present on classpath
-    try (InputStream customIn = DefaultGCPLengthProvider.class.getResourceAsStream(CUSTOM_RESOURCE)) {
-      if (customIn != null) {
-        List<Entry> custom = loadFromResource(customIn);
-        list.addAll(custom);
-        log.info("Loaded {} custom GCP prefix entries from {}", custom.size(), CUSTOM_RESOURCE);
-      }
-    } catch (Exception e) {
-      log.warn("Failed to load custom GCP prefixes from {}: {}", CUSTOM_RESOURCE, e.getMessage());
+    static {
+        log.info("Loading {}", RESOURCE);
+        PREFIX_ENTRIES = loadPrefixEntries();
+        log.info("Loaded {} GCP prefixes", PREFIX_ENTRIES.size());
     }
 
-    list.sort(Comparator
-            .comparingInt((Entry e) -> e.prefix().length())
-            .reversed()
-            .thenComparing(Entry::prefix));
+    private static List<Entry> loadPrefixEntries() {
+        final List<Entry> list = loadFromResource(RESOURCE, true);
 
-    return List.copyOf(list);
-  }
+        // Merge custom overlay entries if present on classpath
+        try (InputStream customIn = DefaultGCPLengthProvider.class.getResourceAsStream(CUSTOM_RESOURCE)) {
+            if (customIn != null) {
+                List<Entry> custom = loadFromResource(customIn);
+                list.addAll(custom);
+                log.info("Loaded {} custom GCP prefix entries from {}", custom.size(), CUSTOM_RESOURCE);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to load custom GCP prefixes from {}: {}", CUSTOM_RESOURCE, e.getMessage());
+        }
 
-  private static List<Entry> loadFromResource(String resource, boolean required) {
-    try (InputStream in = required
-            ? Objects.requireNonNull(
-                    DefaultGCPLengthProvider.class.getResourceAsStream(resource),
-                    resource + " not found on classpath")
-            : DefaultGCPLengthProvider.class.getResourceAsStream(resource)) {
-      if (in == null) return new ArrayList<>();
-      return loadFromResource(in);
-    } catch (IOException e) {
-      log.error("Failed to read {}", resource, e);
-      throw new UrnDLTransformationException("Cannot initialise GCP length map", e);
-    }
-  }
-
-  private static List<Entry> loadFromResource(InputStream in) throws IOException {
-    final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
-    final JsonNode root = mapper.readTree(in)
-            .path("GCPPrefixFormatList")
-            .path("entry");
-
-    final List<Entry> list = new ArrayList<>(root.size());
-    for (JsonNode n : root) {
-      list.add(new Entry(
-              n.get("prefix").asText(),
-              n.get("gcpLength").asInt()
-      ));
-    }
-    return list;
-  }
-
-  /* ------------------------------------------------------------------ *
-   *  Singleton boiler-plate                                             *
-   * ------------------------------------------------------------------ */
-
-  private static final DefaultGCPLengthProvider INSTANCE =
-          new DefaultGCPLengthProvider();
-
-  private DefaultGCPLengthProvider() {}     // prevent external instantiation
-
-  public static DefaultGCPLengthProvider getInstance() {
-    return INSTANCE;
-  }
-
-  /* ------------------------------------------------------------------ *
-   *  Public API                                                         *
-   * ------------------------------------------------------------------ */
-
-  /**
-   * Resolve the GCP length for a full Digital Link URI.
-   *
-   * @throws UnsupportedGS1IdentifierException if the URI is blank, a URN,
-   *         or no matching GCP can be found and no default is configured
-   */
-  public int getGcpLength(final String gs1DigitalLinkURI) {
-    if (StringUtils.isBlank(gs1DigitalLinkURI) ||
-            gs1DigitalLinkURI.contains("urn:")) {
-      throw new UnsupportedGS1IdentifierException(
-              "GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT);
+        list.sort(Comparator.comparingInt((Entry e) -> e.prefix().length()).reversed().thenComparing(Entry::prefix));
+        return List.copyOf(list);
     }
 
-    // pattern: /<digits>/…  or  …/<digits>/…
-    final Pattern p = Pattern.compile("(/|^)(\\d+/|/\\d+/)([^/]+)");
-    final Matcher m = p.matcher(gs1DigitalLinkURI);
-
-    if (m.find()) {
-      final String prefix = m.group(2).startsWith("/")
-              ? m.group(2)
-              : "/" + m.group(2);
-      final String identifier = m.group(3);
-      return getGcpLength(gs1DigitalLinkURI, identifier, prefix);
-    }
-    throw new UnsupportedGS1IdentifierException(
-            "GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT);
-  }
-
-  /**
-   * Core lookup that assumes the caller already split out the GS1 prefix.
-   */
-  public int getGcpLength(final String gs1DigitalLinkURI,
-                          String identifier,
-                          final String gs1IdentifierPrefix) {
-
-    // GTINs: ignore first digit unless prefix itself embeds full GCP
-    if (!PREFIXES_WITH_GCP.contains(gs1IdentifierPrefix) &&
-            identifier.length() > 13) {
-      identifier = identifier.substring(1);
+    private static List<Entry> loadFromResource(String resource, boolean required) {
+        try (InputStream in = required
+                ? Objects.requireNonNull(DefaultGCPLengthProvider.class.getResourceAsStream(resource), resource + " not found on classpath")
+                : DefaultGCPLengthProvider.class.getResourceAsStream(resource)) {
+            if (in == null) return new ArrayList<>();
+            return loadFromResource(in);
+        } catch (IOException e) {
+            log.error("Failed to read {}", resource, e);
+            throw new UrnDLTransformationException("Cannot initialise GCP length map", e);
+        }
     }
 
-    for (Entry e : PREFIX_ENTRIES) {
-      if (identifier.startsWith(e.prefix())) {
-        return e.len();
-      }
+    private static List<Entry> loadFromResource(InputStream in) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        final JsonNode root = mapper.readTree(in).path("GCPPrefixFormatList").path("entry");
+
+        final List<Entry> list = new ArrayList<>(root.size());
+        for (JsonNode n : root) {
+            list.add(new Entry(n.get("prefix").asText(), n.get("gcpLength").asInt()));
+        }
+        return list;
     }
 
-    // optional JVM override: -Dio.openepcis...defaultGcpLength=7
-    final String prop = System.getProperty(
-            getClass().getName() + ".defaultGcpLength");
-    if (prop != null) {
-      try {
-        return Integer.parseInt(prop);
-      } catch (NumberFormatException nfe) {
-        throw new IllegalArgumentException(
-                "Invalid default GCP length value: " + prop, nfe);
-      }
+    /* ------------------------------------------------------------------ *
+     *  Singleton boiler-plate                                             *
+     * ------------------------------------------------------------------ */
+
+    private static final DefaultGCPLengthProvider INSTANCE = new DefaultGCPLengthProvider();
+
+    private DefaultGCPLengthProvider() {
+    }     // prevent external instantiation
+
+    public static DefaultGCPLengthProvider getInstance() {
+        return INSTANCE;
     }
 
-    throw new UnsupportedGS1IdentifierException(
-            "GCP length not found for Digital Link URI: " +
-                    gs1DigitalLinkURI + ". " + NO_GCP_HINT);
-  }
+    /* ------------------------------------------------------------------ *
+     *  Public API                                                         *
+     * ------------------------------------------------------------------ */
 
-  /* ------------------------------------------------------------------ *
-   *  Internal value object                                              *
-   * ------------------------------------------------------------------ */
+    /**
+     * Resolve the GCP length for a full Digital Link URI.
+     *
+     * @throws UnsupportedGS1IdentifierException if the URI is blank, a URN,
+     *                                           or no matching GCP can be found and no default is configured
+     */
+    public int getGcpLength(final String gs1DigitalLinkURI) {
+        if (StringUtils.isBlank(gs1DigitalLinkURI) || gs1DigitalLinkURI.contains("urn:")) {
+            throw new UnsupportedGS1IdentifierException("GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT);
+        }
 
-  private record Entry(String prefix, int len) {}
+        // pattern: /<digits>/…  or  …/<digits>/…
+        final Pattern p = Pattern.compile("(/|^)(\\d+/|/\\d+/)([^/]+)");
+        final Matcher m = p.matcher(gs1DigitalLinkURI);
+
+        if (m.find()) {
+            final String prefix = m.group(2).startsWith("/") ? m.group(2) : "/" + m.group(2);
+            final String identifier = m.group(3);
+            return getGcpLength(gs1DigitalLinkURI, identifier, prefix);
+        }
+        throw new UnsupportedGS1IdentifierException("GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT);
+    }
+
+    /**
+     * Core lookup that assumes the caller already split out the GS1 prefix.
+     */
+    public int getGcpLength(final String gs1DigitalLinkURI, String identifier, final String gs1IdentifierPrefix) {
+        // Save original identifier before GTIN stripping (needed for SPI/verifier)
+        final String originalIdentifier = identifier;
+
+        // GTINs: ignore first digit unless prefix itself embeds full GCP
+        if (!PREFIXES_WITH_GCP.contains(gs1IdentifierPrefix) && identifier.length() > 13) {
+            identifier = identifier.substring(1);
+        }
+
+        // Step 1: Static prefix table lookup
+        for (Entry e : PREFIX_ENTRIES) {
+            if (identifier.startsWith(e.prefix())) {
+                return e.len();
+            }
+        }
+
+        // Step 2: SPI-based resolution (e.g. Verified by GS1) - If applicable find from there
+        final GCPLengthResolverManager resolverManager = GCPLengthResolverManager.getInstance();
+        if (resolverManager.hasResolvers()) {
+            try {
+                final OptionalInt spiResult = resolverManager.resolve(originalIdentifier);
+                if (spiResult.isPresent()) {
+                    log.debug("GCP length resolved via SPI for identifier {}: {}", originalIdentifier, spiResult.getAsInt());
+                    return spiResult.getAsInt();
+                }
+            } catch (Exception ex) {
+                log.warn("SPI GCP length resolution failed for {}: {}", originalIdentifier, ex.getMessage());
+            }
+        }
+
+        // Step 3: JVM property default
+        // optional JVM override: -Dio.openepcis...defaultGcpLength=9
+        final String prop = System.getProperty(getClass().getName() + ".defaultGcpLength");
+        if (prop != null) {
+            try {
+                return Integer.parseInt(prop);
+            } catch (NumberFormatException nfe) {
+                throw new IllegalArgumentException("Invalid default GCP length value: " + prop, nfe);
+            }
+        }
+
+        throw new UnsupportedGS1IdentifierException("GCP length not found for Digital Link URI: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT);
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Internal value object                                              *
+     * ------------------------------------------------------------------ */
+
+    private record Entry(String prefix, int len) {
+    }
 }

--- a/utils/src/main/java/io/openepcis/digitallink/utils/DefaultGCPLengthProvider.java
+++ b/utils/src/main/java/io/openepcis/digitallink/utils/DefaultGCPLengthProvider.java
@@ -153,7 +153,11 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
         // Step 1: Static prefix table lookup
         for (Entry e : PREFIX_ENTRIES) {
             if (identifier.startsWith(e.prefix())) {
-                return e.len();
+                if (e.len() > 0) {
+                    return e.len();
+                }
+                log.debug("Prefix table returned GCP length 0 for identifier {}, falling through to SPI resolution", originalIdentifier);
+                break;
             }
         }
 

--- a/utils/src/main/java/io/openepcis/digitallink/utils/resolver/GCPLengthResolver.java
+++ b/utils/src/main/java/io/openepcis/digitallink/utils/resolver/GCPLengthResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022-2025 benelog GmbH & Co. KG
+ * All rights reserved.
+ *
+ * Unauthorized copying, modification, distribution,
+ * or use of this work, via any medium, is strictly prohibited.
+ *
+ * benelog GmbH & Co. KG reserves all rights not expressly granted herein,
+ * including the right to sell licenses for using this work.
+ */
+package io.openepcis.digitallink.utils.resolver;
+
+import java.util.OptionalInt;
+
+/**
+ * SPI interface for resolving GCP (GS1 Company Prefix) lengths from external services when the static prefix table has no match.
+ */
+public interface GCPLengthResolver {
+
+    /**
+     * Attempt to resolve the GCP length for the given raw GS1 identifier
+     * (e.g. a GTIN like "04068194000004" or a GLN like "4068194000004").
+     */
+    OptionalInt resolve(final String identifier);
+
+    /**
+     * Priority order — lower values are tried first. Default is 100.
+     */
+    default int priority() {
+        return 100;
+    }
+}

--- a/utils/src/main/java/io/openepcis/digitallink/utils/resolver/GCPLengthResolverManager.java
+++ b/utils/src/main/java/io/openepcis/digitallink/utils/resolver/GCPLengthResolverManager.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022-2025 benelog GmbH & Co. KG
+ * All rights reserved.
+ *
+ * Unauthorized copying, modification, distribution,
+ * or use of this work, via any medium, is strictly prohibited.
+ *
+ * benelog GmbH & Co. KG reserves all rights not expressly granted herein,
+ * including the right to sell licenses for using this work.
+ */
+
+package io.openepcis.digitallink.utils.resolver;
+
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.ServiceLoader;
+
+@Slf4j
+public class GCPLengthResolverManager {
+
+    private static GCPLengthResolverManager gcpLengthResolverManager;
+    private final List<GCPLengthResolver> resolvers;
+
+    private GCPLengthResolverManager(final List<GCPLengthResolver> resolvers) {
+        this.resolvers = resolvers == null ? List.of() : resolvers.stream().sorted(Comparator.comparingInt(GCPLengthResolver::priority)).toList();
+    }
+
+    public static synchronized GCPLengthResolverManager getInstance() {
+        if (gcpLengthResolverManager == null) {
+            gcpLengthResolverManager = newInstance();
+        }
+        return gcpLengthResolverManager;
+    }
+
+    public static synchronized GCPLengthResolverManager newInstance() {
+        return new GCPLengthResolverManager(ServiceLoader.load(GCPLengthResolver.class).stream().map(ServiceLoader.Provider::get).toList());
+    }
+
+
+    /**
+     * Try each registered resolver in priority order. Returns the first successful (non-empty) result.
+     *
+     * @param identifier the raw GS1 identifier
+     * @return the GCP length, or empty if no resolver can determine it
+     */
+    public OptionalInt resolve(final String identifier) {
+        for (final GCPLengthResolver resolver : resolvers) {
+            try {
+                final OptionalInt result = resolver.resolve(identifier);
+                if (result.isPresent()) {
+                    return result;
+                }
+            } catch (Exception e) {
+                log.warn("GCPLengthResolver {} failed for identifier {}: {}", resolver.getClass().getSimpleName(), identifier, e.getMessage());
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    // return true if at least one resolver is registered via SPI
+    public boolean hasResolvers() {
+        return !resolvers.isEmpty();
+    }
+}

--- a/utils/src/test/java/io/openepcis/digitallink/utils/DefaultGCPLengthProviderTest.java
+++ b/utils/src/test/java/io/openepcis/digitallink/utils/DefaultGCPLengthProviderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022-2025 benelog GmbH & Co. KG
+ * All rights reserved.
+ */
+package io.openepcis.digitallink.utils;
+
+import io.openepcis.core.exception.UnsupportedGS1IdentifierException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultGCPLengthProviderTest {
+
+    private static final String SYS_PROP = "io.openepcis.digitallink.utils.DefaultGCPLengthProvider.defaultGcpLength";
+
+    @AfterEach
+    void clearSystemProperty() {
+        System.clearProperty(SYS_PROP);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "https://id.gs1.org/01/04068194000004",
+            "https://id.gs1.org/01/04012345000009",
+            "https://id.gs1.org/01/00614141000036",
+    })
+    void testStep1_PrefixTableLookup(String uri) {
+        final DefaultGCPLengthProvider provider = DefaultGCPLengthProvider.getInstance();
+        final int gcpLength = provider.getGcpLength(uri);
+        assertTrue(gcpLength >= 4 && gcpLength <= 12, "GCP length should be 4-12, got " + gcpLength + " for " + uri);
+    }
+
+    @Test
+    void testStep3_JvmPropertyDefault() {
+        System.setProperty(SYS_PROP, "9");
+        final DefaultGCPLengthProvider provider = DefaultGCPLengthProvider.getInstance();
+
+        // Step 1 fails → Step 2 fails (no CDI) → Step 3: JVM property = 9
+        try {
+            final int gcpLength = provider.getGcpLength("https://id.gs1.org/01/09889999999999");
+            assertEquals(9, gcpLength, "Should fall to JVM default of 9");
+        } catch (UnsupportedGS1IdentifierException e) {
+            fail("Should not throw when JVM default is set");
+        }
+    }
+
+    @Test
+    void testNoMatchNoDefault_Throws() {
+        System.clearProperty(SYS_PROP);
+        final DefaultGCPLengthProvider provider = DefaultGCPLengthProvider.getInstance();
+        assertThrows(UnsupportedGS1IdentifierException.class, () -> provider.getGcpLength("https://id.gs1.org/01/09889999999999"));
+    }
+
+    @Test
+    void testBlankUri_Throws() {
+        final DefaultGCPLengthProvider provider = DefaultGCPLengthProvider.getInstance();
+        assertThrows(UnsupportedGS1IdentifierException.class, () -> provider.getGcpLength(""));
+    }
+
+    @Test
+    void testNullUri_Throws() {
+        final DefaultGCPLengthProvider provider = DefaultGCPLengthProvider.getInstance();
+        assertThrows(UnsupportedGS1IdentifierException.class, () -> provider.getGcpLength(null));
+    }
+
+    @Test
+    void testUrnUri_Throws() {
+        final DefaultGCPLengthProvider provider = DefaultGCPLengthProvider.getInstance();
+        assertThrows(UnsupportedGS1IdentifierException.class, () -> provider.getGcpLength("urn:epc:id:sgtin:4012345.099999.1234"));
+    }
+}


### PR DESCRIPTION
This PR introduces the integration of the Verified by GS1 service for finding the GCP length of the provided identifiers. If the provided identifiers are not found in the GCP Length table or 0 is returned, default to 9 if verified that GS1 is available. If the Verified by Gs1 is available in the class path, then check for identifiers before defaulting to the JVM property-based GCP length 9. 

 DefaultGCPLengthProvider now follows a 3-step resolution chain: 
 1. Static prefix table (GS1 provided table)
 2. SPI resolvers (if available, then use Verified By GS1)
 3. JVM property default.