### PR TITLE
Java 25 / Quarkus 3.33 LTS, Lombok removed

### DIFF
--- a/converter/core/pom.xml
+++ b/converter/core/pom.xml
@@ -31,10 +31,6 @@
         </dependency>
 
         <!-- For Getter/Setter and other methods -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
 
         <!-- Jackson related dependencies for JSON modifications -->
         <dependency>

--- a/converter/core/src/main/java/io/openepcis/identifiers/converter/StandardVocabConvertorUtil.java
+++ b/converter/core/src/main/java/io/openepcis/identifiers/converter/StandardVocabConvertorUtil.java
@@ -13,14 +13,9 @@ package io.openepcis.identifiers.converter;
 import io.openepcis.core.exception.UnsupportedGS1IdentifierException;
 import io.openepcis.core.exception.ValidationException;
 import io.openepcis.identifiers.converter.constants.StandardVocabElements;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class StandardVocabConvertorUtil {
-
-  private static final String ERROR_MESSAGE =
-      "Provided URN format does not match with any of the GS1 identifiers format.%nPlease check the URN: %s";
+  private static final String ERROR_MESSAGE = "Provided URN format does not match with any of the GS1 identifiers format.%nPlease check the URN: %s";
 
   public static String toURI(String urn) throws ValidationException {
     for (StandardVocabElements element : StandardVocabElements.values()) {
@@ -44,9 +39,9 @@ public class StandardVocabConvertorUtil {
     if (dlURI.startsWith("http://") || dlURI.startsWith("https://")) {
       throw new UnsupportedGS1IdentifierException(String.format(ERROR_MESSAGE, dlURI));
     }
-    throw new ValidationException(
-        String.format(
-            "Provided URI format does not match with any of the GS1 identifiers format.%nPlease check the URI: %s",
-            dlURI));
+    throw new ValidationException(String.format("Provided URI format does not match with any of the GS1 identifiers format.%nPlease check the URI: %s", dlURI));
+  }
+
+  private StandardVocabConvertorUtil() {
   }
 }

--- a/converter/core/src/main/java/io/openepcis/identifiers/converter/constants/ConstantDigitalLinkTranslatorInfo.java
+++ b/converter/core/src/main/java/io/openepcis/identifiers/converter/constants/ConstantDigitalLinkTranslatorInfo.java
@@ -10,14 +10,13 @@
  */
 package io.openepcis.identifiers.converter.constants;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConstantDigitalLinkTranslatorInfo {
   public static final String AS_CAPTURED = "asCaptured";
   public static final String CANONICAL_DL = "canonicalDL";
   public static final String AS_URN = "asURN";
   public static final String SERIAL = "serial";
   public static final String GCP_LENGTH = " GCP Length : ";
+
+  private ConstantDigitalLinkTranslatorInfo() {
+  }
 }

--- a/converter/core/src/main/java/io/openepcis/identifiers/converter/util/ConverterUtil.java
+++ b/converter/core/src/main/java/io/openepcis/identifiers/converter/util/ConverterUtil.java
@@ -12,15 +12,9 @@ package io.openepcis.identifiers.converter.util;
 
 import io.openepcis.core.exception.ValidationException;
 import io.openepcis.identifiers.converter.Converter;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
 import java.util.Map;
-
 // Class to use the Converter method in a static way.
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConverterUtil {
-
   private static final Converter converter;
 
   static {
@@ -33,8 +27,7 @@ public class ConverterUtil {
   }
 
   // Check through each class and find DL URI belongs to which particular class
-  public static Map<String, String> toURN(final String dlURI, final int gcpLength)
-      throws ValidationException {
+  public static Map<String, String> toURN(final String dlURI, final int gcpLength) throws ValidationException {
     return converter.toURN(dlURI, gcpLength);
   }
 
@@ -49,14 +42,12 @@ public class ConverterUtil {
   }
 
   // Check through each class and find DL URI belongs to which particular class
-  public static Map<String, String> toURNForClassLevelIdentifier(final String dlURI)
-      throws ValidationException {
+  public static Map<String, String> toURNForClassLevelIdentifier(final String dlURI) throws ValidationException {
     return converter.toURNForClassLevelIdentifier(dlURI);
   }
 
   // Check through each class and find DL URI belongs to which particular class
-  public static Map<String, String> toURNForClassLevelIdentifier(
-      final String dlURI, final int gcpLength) throws ValidationException {
+  public static Map<String, String> toURNForClassLevelIdentifier(final String dlURI, final int gcpLength) throws ValidationException {
     return converter.toURNForClassLevelIdentifier(dlURI, gcpLength);
   }
 
@@ -78,8 +69,7 @@ public class ConverterUtil {
   }
 
   // Convert bareString values to CBV formatted vocabularies. Used during JSON -> XML conversion.
-  public static String toCbvVocabulary(
-      final String bareString, final String fieldName, final String format) {
+  public static String toCbvVocabulary(final String bareString, final String fieldName, final String format) {
     return converter.toCbvVocabulary(bareString, fieldName, format);
   }
 
@@ -104,5 +94,8 @@ public class ConverterUtil {
       index = 0;
     }
     return Character.forDigit(index, 10);
+  }
+
+  private ConverterUtil() {
   }
 }

--- a/qrcode-generator/core/pom.xml
+++ b/qrcode-generator/core/pom.xml
@@ -37,10 +37,6 @@
         </dependency>
 
         <!-- For Getter/Setter and other methods -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
 
         <!-- ZXing core + javase for QR code generation and processing -->
         <dependency>

--- a/qrcode-generator/core/src/main/java/io/openepcis/qrcode/generator/QrCodeConfig.java
+++ b/qrcode-generator/core/src/main/java/io/openepcis/qrcode/generator/QrCodeConfig.java
@@ -15,219 +15,1009 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openepcis.qrcode.generator.util.ColorDeserializer;
 import io.openepcis.qrcode.generator.util.ColorSerializer;
-import lombok.*;
-import lombok.extern.jackson.Jacksonized;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-
 import java.awt.*;
 
 /**
  * Holds configuration for generating a QR code. Provides a Builder, so we can set only the fields we need.
  */
-@Jacksonized
-@Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Getter
-@Setter
-@ToString
 @Schema(description = "Holds configuration for generating a QR code. Provides a Builder, so we can set only the fields we need.")
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = QrCodeConfig.QrCodeConfigBuilder.class)
 public final class QrCodeConfig {
-
     // Required: The data (URL or text) to encode in the QR code.
-    @NonNull
     @Schema(description = "The data (URL or text) to encode in the QR code.", examples = {"https://example.com"}, required = true)
     private String data;
-
     // Optional fields (with defaults):
     /**
      * Name associated with the QR code to be generated. If EPCIS/GS1 then corresponding default values will be used from extensions module.
      */
     @Schema(description = "The Design Preset associated with the QR code.", examples = {"openepcis", "gs1", "epcis"})
-    @Builder.Default
-    private String designPreset = null;
-
+    private String designPreset;
     /**
      * The output file format (e.g., "image/png", "image/jpeg). Defaults to image/png
      */
-    @Schema(description = "The output file format (e.g., 'image/png', 'image/jpeg', 'image/gif').", examples = {"image/png"}, defaultValue = "image/png")
-    @Builder.Default
-    private String mimeType = "image/png";
-
+    @Schema(description = "The output file format (e.g., \'image/png\', \'image/jpeg\', \'image/gif\').", examples = {"image/png"}, defaultValue = "image/png")
+    private String mimeType;
     /**
      * Convert to uppercase URL for better compression. Default is true.
-     **/
+     */
     @Schema(description = "Convert to uppercase URL for better compression.", examples = "false", defaultValue = "false")
-    @Builder.Default
-    private boolean compressWithUppercase = Boolean.FALSE;
-
+    private boolean compressWithUppercase;
     /**
      * The width of the QR code in pixels. Default is 400.
      */
     @Schema(description = "The width of the QR code in pixels.", examples = "400", defaultValue = "400")
-    @Builder.Default
-    private int qrWidth = 400;
-
+    private int qrWidth;
     /**
      * The height of the QR code in pixels. Default is 400.
      */
     @Schema(description = "The height of the QR code in pixels.", examples = "400", defaultValue = "400")
-    @Builder.Default
-    private int qrHeight = 400;
-
+    private int qrHeight;
     /**
      * Quiet zone (margin) around the QR code, in modules. Default is 4.
      */
     @Schema(description = "Quiet zone (margin) around the QR code, in modules.", examples = "4", defaultValue = "4")
-    @Builder.Default
-    private int margin = 4;
-
+    private int margin;
     /**
      * Background color of the entire QR image. Default is Color.WHITE.
      */
-    @Builder.Default
     @Schema(description = "Background color of the entire QR image.", examples = "{\"red\": 255, \"green\": 255, \"blue\": 255, \"alpha\": 255}", defaultValue = "White")
     @JsonSerialize(using = ColorSerializer.class)
     @JsonDeserialize(using = ColorDeserializer.class)
-    private Color backgroundColor = Color.WHITE;
-
+    private Color backgroundColor;
     /**
      * The start color of the module gradient. Default is Color.BLACK.
      */
-    @Builder.Default
     @Schema(description = "The start color of the module gradient.", examples = "{\"red\": 0, \"green\": 0, \"blue\": 0, \"alpha\": 255}", defaultValue = "Black")
     @JsonSerialize(using = ColorSerializer.class)
     @JsonDeserialize(using = ColorDeserializer.class)
-    private Color gradientStart = Color.BLACK;
-
+    private Color gradientStart;
     /**
      * The end color of the module gradient. Default is Color.BLACK (i.e., no visible gradient).
      */
-    @Builder.Default
     @Schema(description = "The end color of the module gradient.", examples = "{\"red\": 0, \"green\": 0, \"blue\": 0, \"alpha\": 255}", defaultValue = "Black")
     @JsonSerialize(using = ColorSerializer.class)
     @JsonDeserialize(using = ColorDeserializer.class)
-    private Color gradientEnd = Color.BLACK;
-
+    private Color gradientEnd;
     /**
      * If true, use a radial gradient; if false, linear gradient. Default is false.
      */
-    @Builder.Default
     @Schema(description = "If true, use a radial gradient; if false, linear gradient.", examples = "false", defaultValue = "false")
-    private boolean useRadialGradient = false;
-
+    private boolean useRadialGradient;
     /**
      * Fallback color for the finder patterns if not drawing them in gradient. Default: Color.BLACK.
      */
-    @Builder.Default
     @Schema(description = "Fallback color for the finder patterns.", examples = "{\"red\": 0, \"green\": 0, \"blue\": 0, \"alpha\": 255}", defaultValue = "Black")
     @JsonSerialize(using = ColorSerializer.class)
     @JsonDeserialize(using = ColorDeserializer.class)
-    private Color finderColor = Color.BLACK;
-
+    private Color finderColor;
     /**
      * If true, apply the gradient to the finder pattern as well. Default is false.
      */
-    @Builder.Default
     @Schema(description = "If true, apply the gradient to the finder pattern.", examples = "false", defaultValue = "false")
-    private boolean drawFinderGradient = false;
-
+    private boolean drawFinderGradient;
     /**
      * Shape of each QR module. Default is SQUARE.
      */
-    @Builder.Default
     @Schema(description = "Shape of each QR module.", examples = "SQUARE", defaultValue = "SQUARE")
-    private ModuleShape moduleShape = ModuleShape.SQUARE;
-
+    private ModuleShape moduleShape;
     /**
      * Text for QR code module if ModuleShape is Name. Default is A
      */
-    @Builder.Default
     @Schema(description = "Text for QR code module if ModuleShape is Name.", examples = "A", defaultValue = "A")
-    private String moduleName = "A";
-
+    private String moduleName;
     /**
      * If true, draw a shadow behind each filled module. Default is false.
      */
-    @Builder.Default
     @Schema(description = "If true, draw a shadow behind each filled module.", examples = "false", defaultValue = "false")
-    private boolean drawShadows = false;
-
+    private boolean drawShadows;
     /**
      * The color of the shadow, can have alpha. Default is semi-transparent black.
      */
-    @Builder.Default
     @Schema(description = "The color of the shadow, can have alpha.", examples = "{\"red\": 0, \"green\": 0, \"blue\": 0, \"alpha\": 50}", defaultValue = "new Color(0, 0, 0, 50)")
     @JsonSerialize(using = ColorSerializer.class)
     @JsonDeserialize(using = ColorDeserializer.class)
-    private Color shadowColor = new Color(0, 0, 0, 50);
-
+    private Color shadowColor;
     /**
      * Offset of the shadow relative to module size. E.g. 0.1f = 10%. Default is 0.1f.
      */
-    @Builder.Default
     @Schema(description = "Offset of the shadow relative to module size. E.g. 0.1f = 10%.", examples = "0.1", defaultValue = "0.1")
-    private float shadowOffsetPct = 0.1f;
-
+    private float shadowOffsetPct;
     /**
      * Optional URL for a logo to overlay at the center. Default is null (no logo).
      */
-    @Builder.Default
     @Schema(description = "Optional URL for a logo to overlay at the center.")
-    private String logoResourceUrl = null;
-
+    private String logoResourceUrl;
     /**
      * The fraction of the QR code size for the logo (e.g. 0.2 = 20%). Default is 0.0f (no visible
      * logo).
      */
-    @Builder.Default
     @Schema(description = "The fraction of the QR code size for the logo.", type = SchemaType.NUMBER, examples = "0.0", defaultValue = "0.0")
-    private float logoScale = 0.0f;
-
+    private float logoScale;
     /**
      * The text label to be displayed at the bottom right (Ex: can be company name, tagline, ect). Default is null
      */
-    @Builder.Default
     @Schema(description = "The label to be displayed at the bottom right.")
-    private String displayLabel = null;
-
+    private String displayLabel;
     /**
      * The company font color. Default: Color.BLACK.
      */
-    @Builder.Default
     @Schema(description = "The company font color.", type = SchemaType.OBJECT, examples = "{\"red\": 0, \"green\": 0, \"blue\": 0, \"alpha\": 255}", defaultValue = "Black")
     @JsonSerialize(using = ColorSerializer.class)
     @JsonDeserialize(using = ColorDeserializer.class)
-    private Color displayLabelFontColor = Color.BLACK;
-
+    private Color displayLabelFontColor;
     /**
      * Add the HRI (Human Readable Interpretation) text below the QR code. Default is false.
      */
-    @Builder.Default
     @Schema(description = "Add the HRI (Human Readable Interpretation) text below the QR code.", type = SchemaType.BOOLEAN, examples = "false", defaultValue = "false")
-    private boolean addHri = false;
-
+    private boolean addHri;
     /**
      * Whether to compress the GS1 Digital Link URL before generating the QR code. Default is false.
      */
-    @Builder.Default
     @Schema(description = "Whether to compress the GS1 Digital Link URI before encoding it into the QR code.", type = SchemaType.BOOLEAN, examples = "false", defaultValue = "false")
-    private boolean compressDigitalLink = false;
+    private boolean compressDigitalLink;
+
 
     /**
      * An enum to define module shapes to generate QR code with different shapes.
      */
     public enum ModuleShape {
-        SQUARE,
-        ROUNDED_RECT,
-        CIRCLE,
-        DOT,
-        HEART,
-        BARCODE,
-        LETTER,
-        STAR,
-        TRIANGLE,
-        DIAMOND,
-        WAVE
+        SQUARE, ROUNDED_RECT, CIRCLE, DOT, HEART, BARCODE, LETTER, STAR, TRIANGLE, DIAMOND, WAVE;
+    }
+
+    private static String $default$designPreset() {
+        return null;
+    }
+
+    private static String $default$mimeType() {
+        return "image/png";
+    }
+
+    private static boolean $default$compressWithUppercase() {
+        return Boolean.FALSE;
+    }
+
+    private static int $default$qrWidth() {
+        return 400;
+    }
+
+    private static int $default$qrHeight() {
+        return 400;
+    }
+
+    private static int $default$margin() {
+        return 4;
+    }
+
+    private static Color $default$backgroundColor() {
+        return Color.WHITE;
+    }
+
+    private static Color $default$gradientStart() {
+        return Color.BLACK;
+    }
+
+    private static Color $default$gradientEnd() {
+        return Color.BLACK;
+    }
+
+    private static boolean $default$useRadialGradient() {
+        return false;
+    }
+
+    private static Color $default$finderColor() {
+        return Color.BLACK;
+    }
+
+    private static boolean $default$drawFinderGradient() {
+        return false;
+    }
+
+    private static ModuleShape $default$moduleShape() {
+        return ModuleShape.SQUARE;
+    }
+
+    private static String $default$moduleName() {
+        return "A";
+    }
+
+    private static boolean $default$drawShadows() {
+        return false;
+    }
+
+    private static Color $default$shadowColor() {
+        return new Color(0, 0, 0, 50);
+    }
+
+    private static float $default$shadowOffsetPct() {
+        return 0.1F;
+    }
+
+    private static String $default$logoResourceUrl() {
+        return null;
+    }
+
+    private static float $default$logoScale() {
+        return 0.0F;
+    }
+
+    private static String $default$displayLabel() {
+        return null;
+    }
+
+    private static Color $default$displayLabelFontColor() {
+        return Color.BLACK;
+    }
+
+    private static boolean $default$addHri() {
+        return false;
+    }
+
+    private static boolean $default$compressDigitalLink() {
+        return false;
+    }
+
+    /**
+     * Creates a new {@code QrCodeConfig} instance.
+     *
+     * @param data
+     * @param designPreset Name associated with the QR code to be generated. If EPCIS/GS1 then corresponding default values will be used from extensions module.
+     * @param mimeType The output file format (e.g., "image/png", "image/jpeg). Defaults to image/png
+     * @param compressWithUppercase Convert to uppercase URL for better compression. Default is true.
+     * @param qrWidth The width of the QR code in pixels. Default is 400.
+     * @param qrHeight The height of the QR code in pixels. Default is 400.
+     * @param margin Quiet zone (margin) around the QR code, in modules. Default is 4.
+     * @param backgroundColor Background color of the entire QR image. Default is Color.WHITE.
+     * @param gradientStart The start color of the module gradient. Default is Color.BLACK.
+     * @param gradientEnd The end color of the module gradient. Default is Color.BLACK (i.e., no visible gradient).
+     * @param useRadialGradient If true, use a radial gradient; if false, linear gradient. Default is false.
+     * @param finderColor Fallback color for the finder patterns if not drawing them in gradient. Default: Color.BLACK.
+     * @param drawFinderGradient If true, apply the gradient to the finder pattern as well. Default is false.
+     * @param moduleShape Shape of each QR module. Default is SQUARE.
+     * @param moduleName Text for QR code module if ModuleShape is Name. Default is A
+     * @param drawShadows If true, draw a shadow behind each filled module. Default is false.
+     * @param shadowColor The color of the shadow, can have alpha. Default is semi-transparent black.
+     * @param shadowOffsetPct Offset of the shadow relative to module size. E.g. 0.1f = 10%. Default is 0.1f.
+     * @param logoResourceUrl Optional URL for a logo to overlay at the center. Default is null (no logo).
+     * @param logoScale The fraction of the QR code size for the logo (e.g. 0.2 = 20%). Default is 0.0f (no visible
+     * logo).
+     * @param displayLabel The text label to be displayed at the bottom right (Ex: can be company name, tagline, ect). Default is null
+     * @param displayLabelFontColor The company font color. Default: Color.BLACK.
+     * @param addHri Add the HRI (Human Readable Interpretation) text below the QR code. Default is false.
+     * @param compressDigitalLink Whether to compress the GS1 Digital Link URL before generating the QR code. Default is false.
+     */
+    QrCodeConfig(String data, String designPreset, String mimeType, boolean compressWithUppercase, int qrWidth, int qrHeight, int margin, Color backgroundColor, Color gradientStart, Color gradientEnd, boolean useRadialGradient, Color finderColor, boolean drawFinderGradient, ModuleShape moduleShape, String moduleName, boolean drawShadows, Color shadowColor, float shadowOffsetPct, String logoResourceUrl, float logoScale, String displayLabel, Color displayLabelFontColor, boolean addHri, boolean compressDigitalLink) {
+        if (data == null) {
+            throw new NullPointerException("data is marked non-null but is null");
+        }
+        this.data = data;
+        this.designPreset = designPreset;
+        this.mimeType = mimeType;
+        this.compressWithUppercase = compressWithUppercase;
+        this.qrWidth = qrWidth;
+        this.qrHeight = qrHeight;
+        this.margin = margin;
+        this.backgroundColor = backgroundColor;
+        this.gradientStart = gradientStart;
+        this.gradientEnd = gradientEnd;
+        this.useRadialGradient = useRadialGradient;
+        this.finderColor = finderColor;
+        this.drawFinderGradient = drawFinderGradient;
+        this.moduleShape = moduleShape;
+        this.moduleName = moduleName;
+        this.drawShadows = drawShadows;
+        this.shadowColor = shadowColor;
+        this.shadowOffsetPct = shadowOffsetPct;
+        this.logoResourceUrl = logoResourceUrl;
+        this.logoScale = logoScale;
+        this.displayLabel = displayLabel;
+        this.displayLabelFontColor = displayLabelFontColor;
+        this.addHri = addHri;
+        this.compressDigitalLink = compressDigitalLink;
+    }
+
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+    public static class QrCodeConfigBuilder {
+        private String data;
+        private boolean designPreset$set;
+        private String designPreset$value;
+        private boolean mimeType$set;
+        private String mimeType$value;
+        private boolean compressWithUppercase$set;
+        private boolean compressWithUppercase$value;
+        private boolean qrWidth$set;
+        private int qrWidth$value;
+        private boolean qrHeight$set;
+        private int qrHeight$value;
+        private boolean margin$set;
+        private int margin$value;
+        private boolean backgroundColor$set;
+        private Color backgroundColor$value;
+        private boolean gradientStart$set;
+        private Color gradientStart$value;
+        private boolean gradientEnd$set;
+        private Color gradientEnd$value;
+        private boolean useRadialGradient$set;
+        private boolean useRadialGradient$value;
+        private boolean finderColor$set;
+        private Color finderColor$value;
+        private boolean drawFinderGradient$set;
+        private boolean drawFinderGradient$value;
+        private boolean moduleShape$set;
+        private ModuleShape moduleShape$value;
+        private boolean moduleName$set;
+        private String moduleName$value;
+        private boolean drawShadows$set;
+        private boolean drawShadows$value;
+        private boolean shadowColor$set;
+        private Color shadowColor$value;
+        private boolean shadowOffsetPct$set;
+        private float shadowOffsetPct$value;
+        private boolean logoResourceUrl$set;
+        private String logoResourceUrl$value;
+        private boolean logoScale$set;
+        private float logoScale$value;
+        private boolean displayLabel$set;
+        private String displayLabel$value;
+        private boolean displayLabelFontColor$set;
+        private Color displayLabelFontColor$value;
+        private boolean addHri$set;
+        private boolean addHri$value;
+        private boolean compressDigitalLink$set;
+        private boolean compressDigitalLink$value;
+
+        QrCodeConfigBuilder() {
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder data(String data) {
+            if (data == null) {
+                throw new NullPointerException("data is marked non-null but is null");
+            }
+            this.data = data;
+            return this;
+        }
+
+        /**
+         * Name associated with the QR code to be generated. If EPCIS/GS1 then corresponding default values will be used from extensions module.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder designPreset(String designPreset) {
+            this.designPreset$value = designPreset;
+            designPreset$set = true;
+            return this;
+        }
+
+        /**
+         * The output file format (e.g., "image/png", "image/jpeg). Defaults to image/png
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder mimeType(String mimeType) {
+            this.mimeType$value = mimeType;
+            mimeType$set = true;
+            return this;
+        }
+
+        /**
+         * Convert to uppercase URL for better compression. Default is true.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder compressWithUppercase(boolean compressWithUppercase) {
+            this.compressWithUppercase$value = compressWithUppercase;
+            compressWithUppercase$set = true;
+            return this;
+        }
+
+        /**
+         * The width of the QR code in pixels. Default is 400.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder qrWidth(int qrWidth) {
+            this.qrWidth$value = qrWidth;
+            qrWidth$set = true;
+            return this;
+        }
+
+        /**
+         * The height of the QR code in pixels. Default is 400.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder qrHeight(int qrHeight) {
+            this.qrHeight$value = qrHeight;
+            qrHeight$set = true;
+            return this;
+        }
+
+        /**
+         * Quiet zone (margin) around the QR code, in modules. Default is 4.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder margin(int margin) {
+            this.margin$value = margin;
+            margin$set = true;
+            return this;
+        }
+
+        /**
+         * Background color of the entire QR image. Default is Color.WHITE.
+         * @return {@code this}.
+         */
+        @JsonDeserialize(using = ColorDeserializer.class)
+        public QrCodeConfig.QrCodeConfigBuilder backgroundColor(Color backgroundColor) {
+            this.backgroundColor$value = backgroundColor;
+            backgroundColor$set = true;
+            return this;
+        }
+
+        /**
+         * The start color of the module gradient. Default is Color.BLACK.
+         * @return {@code this}.
+         */
+        @JsonDeserialize(using = ColorDeserializer.class)
+        public QrCodeConfig.QrCodeConfigBuilder gradientStart(Color gradientStart) {
+            this.gradientStart$value = gradientStart;
+            gradientStart$set = true;
+            return this;
+        }
+
+        /**
+         * The end color of the module gradient. Default is Color.BLACK (i.e., no visible gradient).
+         * @return {@code this}.
+         */
+        @JsonDeserialize(using = ColorDeserializer.class)
+        public QrCodeConfig.QrCodeConfigBuilder gradientEnd(Color gradientEnd) {
+            this.gradientEnd$value = gradientEnd;
+            gradientEnd$set = true;
+            return this;
+        }
+
+        /**
+         * If true, use a radial gradient; if false, linear gradient. Default is false.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder useRadialGradient(boolean useRadialGradient) {
+            this.useRadialGradient$value = useRadialGradient;
+            useRadialGradient$set = true;
+            return this;
+        }
+
+        /**
+         * Fallback color for the finder patterns if not drawing them in gradient. Default: Color.BLACK.
+         * @return {@code this}.
+         */
+        @JsonDeserialize(using = ColorDeserializer.class)
+        public QrCodeConfig.QrCodeConfigBuilder finderColor(Color finderColor) {
+            this.finderColor$value = finderColor;
+            finderColor$set = true;
+            return this;
+        }
+
+        /**
+         * If true, apply the gradient to the finder pattern as well. Default is false.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder drawFinderGradient(boolean drawFinderGradient) {
+            this.drawFinderGradient$value = drawFinderGradient;
+            drawFinderGradient$set = true;
+            return this;
+        }
+
+        /**
+         * Shape of each QR module. Default is SQUARE.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder moduleShape(ModuleShape moduleShape) {
+            this.moduleShape$value = moduleShape;
+            moduleShape$set = true;
+            return this;
+        }
+
+        /**
+         * Text for QR code module if ModuleShape is Name. Default is A
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder moduleName(String moduleName) {
+            this.moduleName$value = moduleName;
+            moduleName$set = true;
+            return this;
+        }
+
+        /**
+         * If true, draw a shadow behind each filled module. Default is false.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder drawShadows(boolean drawShadows) {
+            this.drawShadows$value = drawShadows;
+            drawShadows$set = true;
+            return this;
+        }
+
+        /**
+         * The color of the shadow, can have alpha. Default is semi-transparent black.
+         * @return {@code this}.
+         */
+        @JsonDeserialize(using = ColorDeserializer.class)
+        public QrCodeConfig.QrCodeConfigBuilder shadowColor(Color shadowColor) {
+            this.shadowColor$value = shadowColor;
+            shadowColor$set = true;
+            return this;
+        }
+
+        /**
+         * Offset of the shadow relative to module size. E.g. 0.1f = 10%. Default is 0.1f.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder shadowOffsetPct(float shadowOffsetPct) {
+            this.shadowOffsetPct$value = shadowOffsetPct;
+            shadowOffsetPct$set = true;
+            return this;
+        }
+
+        /**
+         * Optional URL for a logo to overlay at the center. Default is null (no logo).
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder logoResourceUrl(String logoResourceUrl) {
+            this.logoResourceUrl$value = logoResourceUrl;
+            logoResourceUrl$set = true;
+            return this;
+        }
+
+        /**
+         * The fraction of the QR code size for the logo (e.g. 0.2 = 20%). Default is 0.0f (no visible
+         * logo).
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder logoScale(float logoScale) {
+            this.logoScale$value = logoScale;
+            logoScale$set = true;
+            return this;
+        }
+
+        /**
+         * The text label to be displayed at the bottom right (Ex: can be company name, tagline, ect). Default is null
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder displayLabel(String displayLabel) {
+            this.displayLabel$value = displayLabel;
+            displayLabel$set = true;
+            return this;
+        }
+
+        /**
+         * The company font color. Default: Color.BLACK.
+         * @return {@code this}.
+         */
+        @JsonDeserialize(using = ColorDeserializer.class)
+        public QrCodeConfig.QrCodeConfigBuilder displayLabelFontColor(Color displayLabelFontColor) {
+            this.displayLabelFontColor$value = displayLabelFontColor;
+            displayLabelFontColor$set = true;
+            return this;
+        }
+
+        /**
+         * Add the HRI (Human Readable Interpretation) text below the QR code. Default is false.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder addHri(boolean addHri) {
+            this.addHri$value = addHri;
+            addHri$set = true;
+            return this;
+        }
+
+        /**
+         * Whether to compress the GS1 Digital Link URL before generating the QR code. Default is false.
+         * @return {@code this}.
+         */
+        public QrCodeConfig.QrCodeConfigBuilder compressDigitalLink(boolean compressDigitalLink) {
+            this.compressDigitalLink$value = compressDigitalLink;
+            compressDigitalLink$set = true;
+            return this;
+        }
+
+        public QrCodeConfig build() {
+            String designPreset$value = this.designPreset$value;
+            if (!this.designPreset$set) designPreset$value = QrCodeConfig.$default$designPreset();
+            String mimeType$value = this.mimeType$value;
+            if (!this.mimeType$set) mimeType$value = QrCodeConfig.$default$mimeType();
+            boolean compressWithUppercase$value = this.compressWithUppercase$value;
+            if (!this.compressWithUppercase$set) compressWithUppercase$value = QrCodeConfig.$default$compressWithUppercase();
+            int qrWidth$value = this.qrWidth$value;
+            if (!this.qrWidth$set) qrWidth$value = QrCodeConfig.$default$qrWidth();
+            int qrHeight$value = this.qrHeight$value;
+            if (!this.qrHeight$set) qrHeight$value = QrCodeConfig.$default$qrHeight();
+            int margin$value = this.margin$value;
+            if (!this.margin$set) margin$value = QrCodeConfig.$default$margin();
+            Color backgroundColor$value = this.backgroundColor$value;
+            if (!this.backgroundColor$set) backgroundColor$value = QrCodeConfig.$default$backgroundColor();
+            Color gradientStart$value = this.gradientStart$value;
+            if (!this.gradientStart$set) gradientStart$value = QrCodeConfig.$default$gradientStart();
+            Color gradientEnd$value = this.gradientEnd$value;
+            if (!this.gradientEnd$set) gradientEnd$value = QrCodeConfig.$default$gradientEnd();
+            boolean useRadialGradient$value = this.useRadialGradient$value;
+            if (!this.useRadialGradient$set) useRadialGradient$value = QrCodeConfig.$default$useRadialGradient();
+            Color finderColor$value = this.finderColor$value;
+            if (!this.finderColor$set) finderColor$value = QrCodeConfig.$default$finderColor();
+            boolean drawFinderGradient$value = this.drawFinderGradient$value;
+            if (!this.drawFinderGradient$set) drawFinderGradient$value = QrCodeConfig.$default$drawFinderGradient();
+            ModuleShape moduleShape$value = this.moduleShape$value;
+            if (!this.moduleShape$set) moduleShape$value = QrCodeConfig.$default$moduleShape();
+            String moduleName$value = this.moduleName$value;
+            if (!this.moduleName$set) moduleName$value = QrCodeConfig.$default$moduleName();
+            boolean drawShadows$value = this.drawShadows$value;
+            if (!this.drawShadows$set) drawShadows$value = QrCodeConfig.$default$drawShadows();
+            Color shadowColor$value = this.shadowColor$value;
+            if (!this.shadowColor$set) shadowColor$value = QrCodeConfig.$default$shadowColor();
+            float shadowOffsetPct$value = this.shadowOffsetPct$value;
+            if (!this.shadowOffsetPct$set) shadowOffsetPct$value = QrCodeConfig.$default$shadowOffsetPct();
+            String logoResourceUrl$value = this.logoResourceUrl$value;
+            if (!this.logoResourceUrl$set) logoResourceUrl$value = QrCodeConfig.$default$logoResourceUrl();
+            float logoScale$value = this.logoScale$value;
+            if (!this.logoScale$set) logoScale$value = QrCodeConfig.$default$logoScale();
+            String displayLabel$value = this.displayLabel$value;
+            if (!this.displayLabel$set) displayLabel$value = QrCodeConfig.$default$displayLabel();
+            Color displayLabelFontColor$value = this.displayLabelFontColor$value;
+            if (!this.displayLabelFontColor$set) displayLabelFontColor$value = QrCodeConfig.$default$displayLabelFontColor();
+            boolean addHri$value = this.addHri$value;
+            if (!this.addHri$set) addHri$value = QrCodeConfig.$default$addHri();
+            boolean compressDigitalLink$value = this.compressDigitalLink$value;
+            if (!this.compressDigitalLink$set) compressDigitalLink$value = QrCodeConfig.$default$compressDigitalLink();
+            return new QrCodeConfig(this.data, designPreset$value, mimeType$value, compressWithUppercase$value, qrWidth$value, qrHeight$value, margin$value, backgroundColor$value, gradientStart$value, gradientEnd$value, useRadialGradient$value, finderColor$value, drawFinderGradient$value, moduleShape$value, moduleName$value, drawShadows$value, shadowColor$value, shadowOffsetPct$value, logoResourceUrl$value, logoScale$value, displayLabel$value, displayLabelFontColor$value, addHri$value, compressDigitalLink$value);
+        }
+
+        @Override
+        public String toString() {
+            return "QrCodeConfig.QrCodeConfigBuilder(data=" + this.data + ", designPreset$value=" + this.designPreset$value + ", mimeType$value=" + this.mimeType$value + ", compressWithUppercase$value=" + this.compressWithUppercase$value + ", qrWidth$value=" + this.qrWidth$value + ", qrHeight$value=" + this.qrHeight$value + ", margin$value=" + this.margin$value + ", backgroundColor$value=" + this.backgroundColor$value + ", gradientStart$value=" + this.gradientStart$value + ", gradientEnd$value=" + this.gradientEnd$value + ", useRadialGradient$value=" + this.useRadialGradient$value + ", finderColor$value=" + this.finderColor$value + ", drawFinderGradient$value=" + this.drawFinderGradient$value + ", moduleShape$value=" + this.moduleShape$value + ", moduleName$value=" + this.moduleName$value + ", drawShadows$value=" + this.drawShadows$value + ", shadowColor$value=" + this.shadowColor$value + ", shadowOffsetPct$value=" + this.shadowOffsetPct$value + ", logoResourceUrl$value=" + this.logoResourceUrl$value + ", logoScale$value=" + this.logoScale$value + ", displayLabel$value=" + this.displayLabel$value + ", displayLabelFontColor$value=" + this.displayLabelFontColor$value + ", addHri$value=" + this.addHri$value + ", compressDigitalLink$value=" + this.compressDigitalLink$value + ")";
+        }
+    }
+
+    public static QrCodeConfig.QrCodeConfigBuilder builder() {
+        return new QrCodeConfig.QrCodeConfigBuilder();
+    }
+
+    public String getData() {
+        return this.data;
+    }
+
+    /**
+     * Name associated with the QR code to be generated. If EPCIS/GS1 then corresponding default values will be used from extensions module.
+     */
+    public String getDesignPreset() {
+        return this.designPreset;
+    }
+
+    /**
+     * The output file format (e.g., "image/png", "image/jpeg). Defaults to image/png
+     */
+    public String getMimeType() {
+        return this.mimeType;
+    }
+
+    /**
+     * Convert to uppercase URL for better compression. Default is true.
+     */
+    public boolean isCompressWithUppercase() {
+        return this.compressWithUppercase;
+    }
+
+    /**
+     * The width of the QR code in pixels. Default is 400.
+     */
+    public int getQrWidth() {
+        return this.qrWidth;
+    }
+
+    /**
+     * The height of the QR code in pixels. Default is 400.
+     */
+    public int getQrHeight() {
+        return this.qrHeight;
+    }
+
+    /**
+     * Quiet zone (margin) around the QR code, in modules. Default is 4.
+     */
+    public int getMargin() {
+        return this.margin;
+    }
+
+    /**
+     * Background color of the entire QR image. Default is Color.WHITE.
+     */
+    public Color getBackgroundColor() {
+        return this.backgroundColor;
+    }
+
+    /**
+     * The start color of the module gradient. Default is Color.BLACK.
+     */
+    public Color getGradientStart() {
+        return this.gradientStart;
+    }
+
+    /**
+     * The end color of the module gradient. Default is Color.BLACK (i.e., no visible gradient).
+     */
+    public Color getGradientEnd() {
+        return this.gradientEnd;
+    }
+
+    /**
+     * If true, use a radial gradient; if false, linear gradient. Default is false.
+     */
+    public boolean isUseRadialGradient() {
+        return this.useRadialGradient;
+    }
+
+    /**
+     * Fallback color for the finder patterns if not drawing them in gradient. Default: Color.BLACK.
+     */
+    public Color getFinderColor() {
+        return this.finderColor;
+    }
+
+    /**
+     * If true, apply the gradient to the finder pattern as well. Default is false.
+     */
+    public boolean isDrawFinderGradient() {
+        return this.drawFinderGradient;
+    }
+
+    /**
+     * Shape of each QR module. Default is SQUARE.
+     */
+    public ModuleShape getModuleShape() {
+        return this.moduleShape;
+    }
+
+    /**
+     * Text for QR code module if ModuleShape is Name. Default is A
+     */
+    public String getModuleName() {
+        return this.moduleName;
+    }
+
+    /**
+     * If true, draw a shadow behind each filled module. Default is false.
+     */
+    public boolean isDrawShadows() {
+        return this.drawShadows;
+    }
+
+    /**
+     * The color of the shadow, can have alpha. Default is semi-transparent black.
+     */
+    public Color getShadowColor() {
+        return this.shadowColor;
+    }
+
+    /**
+     * Offset of the shadow relative to module size. E.g. 0.1f = 10%. Default is 0.1f.
+     */
+    public float getShadowOffsetPct() {
+        return this.shadowOffsetPct;
+    }
+
+    /**
+     * Optional URL for a logo to overlay at the center. Default is null (no logo).
+     */
+    public String getLogoResourceUrl() {
+        return this.logoResourceUrl;
+    }
+
+    /**
+     * The fraction of the QR code size for the logo (e.g. 0.2 = 20%). Default is 0.0f (no visible
+     * logo).
+     */
+    public float getLogoScale() {
+        return this.logoScale;
+    }
+
+    /**
+     * The text label to be displayed at the bottom right (Ex: can be company name, tagline, ect). Default is null
+     */
+    public String getDisplayLabel() {
+        return this.displayLabel;
+    }
+
+    /**
+     * The company font color. Default: Color.BLACK.
+     */
+    public Color getDisplayLabelFontColor() {
+        return this.displayLabelFontColor;
+    }
+
+    /**
+     * Add the HRI (Human Readable Interpretation) text below the QR code. Default is false.
+     */
+    public boolean isAddHri() {
+        return this.addHri;
+    }
+
+    /**
+     * Whether to compress the GS1 Digital Link URL before generating the QR code. Default is false.
+     */
+    public boolean isCompressDigitalLink() {
+        return this.compressDigitalLink;
+    }
+
+    public void setData(String data) {
+        if (data == null) {
+            throw new NullPointerException("data is marked non-null but is null");
+        }
+        this.data = data;
+    }
+
+    /**
+     * Name associated with the QR code to be generated. If EPCIS/GS1 then corresponding default values will be used from extensions module.
+     */
+    public void setDesignPreset(String designPreset) {
+        this.designPreset = designPreset;
+    }
+
+    /**
+     * The output file format (e.g., "image/png", "image/jpeg). Defaults to image/png
+     */
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    /**
+     * Convert to uppercase URL for better compression. Default is true.
+     */
+    public void setCompressWithUppercase(boolean compressWithUppercase) {
+        this.compressWithUppercase = compressWithUppercase;
+    }
+
+    /**
+     * The width of the QR code in pixels. Default is 400.
+     */
+    public void setQrWidth(int qrWidth) {
+        this.qrWidth = qrWidth;
+    }
+
+    /**
+     * The height of the QR code in pixels. Default is 400.
+     */
+    public void setQrHeight(int qrHeight) {
+        this.qrHeight = qrHeight;
+    }
+
+    /**
+     * Quiet zone (margin) around the QR code, in modules. Default is 4.
+     */
+    public void setMargin(int margin) {
+        this.margin = margin;
+    }
+
+    /**
+     * Background color of the entire QR image. Default is Color.WHITE.
+     */
+    public void setBackgroundColor(Color backgroundColor) {
+        this.backgroundColor = backgroundColor;
+    }
+
+    /**
+     * The start color of the module gradient. Default is Color.BLACK.
+     */
+    public void setGradientStart(Color gradientStart) {
+        this.gradientStart = gradientStart;
+    }
+
+    /**
+     * The end color of the module gradient. Default is Color.BLACK (i.e., no visible gradient).
+     */
+    public void setGradientEnd(Color gradientEnd) {
+        this.gradientEnd = gradientEnd;
+    }
+
+    /**
+     * If true, use a radial gradient; if false, linear gradient. Default is false.
+     */
+    public void setUseRadialGradient(boolean useRadialGradient) {
+        this.useRadialGradient = useRadialGradient;
+    }
+
+    /**
+     * Fallback color for the finder patterns if not drawing them in gradient. Default: Color.BLACK.
+     */
+    public void setFinderColor(Color finderColor) {
+        this.finderColor = finderColor;
+    }
+
+    /**
+     * If true, apply the gradient to the finder pattern as well. Default is false.
+     */
+    public void setDrawFinderGradient(boolean drawFinderGradient) {
+        this.drawFinderGradient = drawFinderGradient;
+    }
+
+    /**
+     * Shape of each QR module. Default is SQUARE.
+     */
+    public void setModuleShape(ModuleShape moduleShape) {
+        this.moduleShape = moduleShape;
+    }
+
+    /**
+     * Text for QR code module if ModuleShape is Name. Default is A
+     */
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    /**
+     * If true, draw a shadow behind each filled module. Default is false.
+     */
+    public void setDrawShadows(boolean drawShadows) {
+        this.drawShadows = drawShadows;
+    }
+
+    /**
+     * The color of the shadow, can have alpha. Default is semi-transparent black.
+     */
+    public void setShadowColor(Color shadowColor) {
+        this.shadowColor = shadowColor;
+    }
+
+    /**
+     * Offset of the shadow relative to module size. E.g. 0.1f = 10%. Default is 0.1f.
+     */
+    public void setShadowOffsetPct(float shadowOffsetPct) {
+        this.shadowOffsetPct = shadowOffsetPct;
+    }
+
+    /**
+     * Optional URL for a logo to overlay at the center. Default is null (no logo).
+     */
+    public void setLogoResourceUrl(String logoResourceUrl) {
+        this.logoResourceUrl = logoResourceUrl;
+    }
+
+    /**
+     * The fraction of the QR code size for the logo (e.g. 0.2 = 20%). Default is 0.0f (no visible
+     * logo).
+     */
+    public void setLogoScale(float logoScale) {
+        this.logoScale = logoScale;
+    }
+
+    /**
+     * The text label to be displayed at the bottom right (Ex: can be company name, tagline, ect). Default is null
+     */
+    public void setDisplayLabel(String displayLabel) {
+        this.displayLabel = displayLabel;
+    }
+
+    /**
+     * The company font color. Default: Color.BLACK.
+     */
+    public void setDisplayLabelFontColor(Color displayLabelFontColor) {
+        this.displayLabelFontColor = displayLabelFontColor;
+    }
+
+    /**
+     * Add the HRI (Human Readable Interpretation) text below the QR code. Default is false.
+     */
+    public void setAddHri(boolean addHri) {
+        this.addHri = addHri;
+    }
+
+    /**
+     * Whether to compress the GS1 Digital Link URL before generating the QR code. Default is false.
+     */
+    public void setCompressDigitalLink(boolean compressDigitalLink) {
+        this.compressDigitalLink = compressDigitalLink;
+    }
+
+    @Override
+    public String toString() {
+        return "QrCodeConfig(data=" + this.getData() + ", designPreset=" + this.getDesignPreset() + ", mimeType=" + this.getMimeType() + ", compressWithUppercase=" + this.isCompressWithUppercase() + ", qrWidth=" + this.getQrWidth() + ", qrHeight=" + this.getQrHeight() + ", margin=" + this.getMargin() + ", backgroundColor=" + this.getBackgroundColor() + ", gradientStart=" + this.getGradientStart() + ", gradientEnd=" + this.getGradientEnd() + ", useRadialGradient=" + this.isUseRadialGradient() + ", finderColor=" + this.getFinderColor() + ", drawFinderGradient=" + this.isDrawFinderGradient() + ", moduleShape=" + this.getModuleShape() + ", moduleName=" + this.getModuleName() + ", drawShadows=" + this.isDrawShadows() + ", shadowColor=" + this.getShadowColor() + ", shadowOffsetPct=" + this.getShadowOffsetPct() + ", logoResourceUrl=" + this.getLogoResourceUrl() + ", logoScale=" + this.getLogoScale() + ", displayLabel=" + this.getDisplayLabel() + ", displayLabelFontColor=" + this.getDisplayLabelFontColor() + ", addHri=" + this.isAddHri() + ", compressDigitalLink=" + this.isCompressDigitalLink() + ")";
     }
 }

--- a/qrcode-generator/core/src/main/java/io/openepcis/qrcode/generator/QrCodeGenerator.java
+++ b/qrcode-generator/core/src/main/java/io/openepcis/qrcode/generator/QrCodeGenerator.java
@@ -19,9 +19,7 @@ import io.openepcis.digitallink.toolkit.GS1DigitalLinkCompression;
 import io.openepcis.digitallink.utils.GS1DigitalLinkParser;
 import io.openepcis.qrcode.generator.exception.QrCodeGeneratorException;
 import io.openepcis.qrcode.generator.spi.service.QrCodeConfigService;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
@@ -41,19 +39,16 @@ import java.util.*;
  * QrCodeGenerator generates a QR code image with optional logo, display label, and HRI,
  * ensuring all visual elements are proportionate to the QR code's dimensions.
  */
-@Slf4j
 public class QrCodeGenerator {
-
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(QrCodeGenerator.class);
     private final GS1DigitalLinkCompression compressor = new GS1DigitalLinkCompression();
     private final QrCodeConfigService qrCodeConfigService = QrCodeConfigService.getInstance();
     private static Font OCR_B_FONT;
 
-
     static {
         try {
             // Load the OCR-B font from the system or classpath
-            OCR_B_FONT = Font.createFont(Font.TRUETYPE_FONT, Objects.requireNonNull(QrCodeGenerator.class.getResourceAsStream("/OCR-B/font/OCR-B.ttf")))
-                    .deriveFont(Font.PLAIN, 12);
+            OCR_B_FONT = Font.createFont(Font.TRUETYPE_FONT, Objects.requireNonNull(QrCodeGenerator.class.getResourceAsStream("/OCR-B/font/OCR-B.ttf"))).deriveFont(Font.PLAIN, 12);
             GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(OCR_B_FONT);
             log.info("Loaded OCR-B font: " + OCR_B_FONT.getFontName());
         } catch (Exception e) {
@@ -70,43 +65,37 @@ public class QrCodeGenerator {
      */
     public byte[] generateQRCode(final QrCodeConfig qrCodeConfig) {
         log.debug("Generating QR code with config: {}", qrCodeConfig);
-
         try {
             // Use SPI to apply default configuration values (if any provider supports the provided name)
             final QrCodeConfig config = qrCodeConfigService.applyDefaultConfig(qrCodeConfig);
-
             // Create a HashMap to store encoding hints (including CHARACTER_SET or MARGIN).
             final Map<EncodeHintType, Object> encodingHints = new HashMap<>();
             encodingHints.put(EncodeHintType.CHARACTER_SET, StandardCharsets.ISO_8859_1);
             encodingHints.put(EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.H);
             encodingHints.put(EncodeHintType.MARGIN, config.getMargin());
-
             // Create a Zxing QRCodeWriter object to generate the QR code.
             final String qrContent = prepareQrData(config);
             final QRCodeWriter qrWriter = new QRCodeWriter();
             final BitMatrix bitMatrix = qrWriter.encode(qrContent, BarcodeFormat.QR_CODE, 1, 1, encodingHints);
-
             // Create a BufferedImage (ARGB) to hold the QR code image.
             final BufferedImage qrImage = new BufferedImage(config.getQrWidth(), config.getQrHeight(), BufferedImage.TYPE_INT_ARGB);
             final Graphics2D qrGraphics = qrImage.createGraphics();
             qrGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             qrGraphics.setColor(config.getBackgroundColor());
             qrGraphics.fillRect(0, 0, config.getQrWidth(), config.getQrHeight());
-
             // Compute module size (pixels per matrix cell)
             final int matrixWidth = bitMatrix.getWidth();
             final int matrixHeight = bitMatrix.getHeight();
             final float moduleSizeX = (float) config.getQrWidth() / matrixWidth;
             final float moduleSizeY = (float) config.getQrHeight() / matrixHeight;
             final float moduleSize = Math.min(moduleSizeX, moduleSizeY);
-
             // Paint for modules (gradient or solid)
-            final Paint modulePaint =
-                    createGradientPaint(config.getQrWidth(), config.getQrHeight(),
-                            config.getGradientStart(), config.getGradientEnd(), config.isUseRadialGradient());
-
+            final Paint modulePaint = createGradientPaint(config.getQrWidth(), config.getQrHeight(), config.getGradientStart(), config.getGradientEnd(), config.isUseRadialGradient());
             // Calculate logo bounding box (centered, proportional to QR size)
-            int logoX = 0, logoY = 0, logoW = 0, logoH = 0;
+            int logoX = 0;
+            int logoY = 0;
+            int logoW = 0;
+            int logoH = 0;
             boolean skipLogoArea = false;
             if (config.getLogoResourceUrl() != null && StringUtils.isNotBlank(config.getLogoResourceUrl())) {
                 // Pre-calculate the bounding box for the logo
@@ -116,63 +105,52 @@ public class QrCodeGenerator {
                 logoY = (config.getQrHeight() - logoH) / 2;
                 skipLogoArea = true; // We want to skip drawing modules in that center area
             }
-
             // Draw regular modules (excluding finder pattern areas, and excluding center area if skipLogoArea is true
             for (int y = 0; y < matrixHeight; y++) {
                 for (int x = 0; x < matrixWidth; x++) {
                     boolean isFinder = isInFinderPattern(x, y, matrixWidth, matrixHeight);
-
                     if (bitMatrix.get(x, y) && !isFinder) {
                         // Convert (x,y) in the matrix to actual pixel cords
                         final float px = x * moduleSizeX;
                         final float py = y * moduleSizeY;
                         final float moduleRight = px + moduleSizeX;
                         final float moduleBottom = py + moduleSizeY;
-
                         // If we must skip the center bounding box for the logo:
-                        if (skipLogoArea
-                                && doesOverlap(px, py, moduleRight, moduleBottom, logoX, logoY, logoW, logoH)) {
+                        if (skipLogoArea && doesOverlap(px, py, moduleRight, moduleBottom, logoX, logoY, logoW, logoH)) {
                             // do NOT draw here, leave blank for the Logo
                             continue;
                         }
-
                         // Otherwise, draw the module
                         drawSingleModule(qrGraphics, x, y, moduleSizeX, moduleSizeY, moduleSize, config.getModuleShape(), config.isDrawShadows(), config.getShadowColor(), config.getShadowOffsetPct(), modulePaint);
                     }
                 }
             }
-
             // Draw the finder patterns (3 corner squares) for easy detection by QR code readers
             final Paint finderPaint = (config.isDrawFinderGradient()) ? modulePaint : config.getFinderColor();
             drawFinderPattern(qrGraphics, bitMatrix, 0, 0, moduleSize, config, finderPaint); // top-left
-            drawFinderPattern(qrGraphics, bitMatrix, matrixWidth - 7, 0, moduleSize, config, finderPaint);  // top-right
+            drawFinderPattern(qrGraphics, bitMatrix, matrixWidth - 7, 0, moduleSize, config, finderPaint); // top-right
             drawFinderPattern(qrGraphics, bitMatrix, 0, matrixHeight - 7, moduleSize, config, finderPaint); // bottom-left
-
             // Step-3: Draw the logo in the center if provided
             if (skipLogoArea) {
                 drawLogo(qrGraphics, config.getLogoResourceUrl(), logoX, logoY, logoW, logoH);
             }
-
             // Draw display label, right-aligned, proportional font size
             if (StringUtils.isNotBlank(config.getDisplayLabel())) {
                 log.debug("Adding label on the right based on provided in config.");
-                final float fontSize = config.getQrHeight() * 0.03f;
+                final float fontSize = config.getQrHeight() * 0.03F;
                 qrGraphics.setColor(config.getDisplayLabelFontColor());
                 qrGraphics.setFont(new Font("Arial", Font.PLAIN, Math.round(fontSize)));
                 final FontMetrics fm = qrGraphics.getFontMetrics();
                 final int labelWidth = fm.stringWidth(config.getDisplayLabel());
-                final int x = Math.round(config.getQrWidth() - labelWidth - config.getQrWidth() * 0.02f);
-                final int y = Math.round(config.getQrHeight() - config.getQrHeight() * 0.02f - fm.getHeight());
+                final int x = Math.round(config.getQrWidth() - labelWidth - config.getQrWidth() * 0.02F);
+                final int y = Math.round(config.getQrHeight() - config.getQrHeight() * 0.02F - fm.getHeight());
                 qrGraphics.drawString(config.getDisplayLabel(), x, y + fm.getAscent());
             }
-
             // Dispose Graphics
             qrGraphics.dispose();
-
             // Try to parse the URL, silently skip HRI if it fails
             boolean isValidUrl = false;
             URL digitalLinkURL = null;
-
             try {
                 digitalLinkURL = new URI(config.getData()).toURL();
                 isValidUrl = true;
@@ -180,13 +158,11 @@ public class QrCodeGenerator {
                 // Not a valid URL, skip HRI
                 log.warn("Failed to parse URL for HRI data, hence skipping them : " + e.getMessage());
             }
-
             // If HRI enabled return generated QR Code image with HRI image
             if (config.isAddHri() && isValidUrl) {
                 log.debug("Adding HRI data to the QR code image");
                 return writeHRIData(digitalLinkURL, config, qrImage);
             }
-
             // If HRI is not enabled, return only the QR code image
             log.debug("Returning only the QR code image");
             return writeImageToBytes(qrImage, config.getMimeType());
@@ -200,20 +176,16 @@ public class QrCodeGenerator {
     private String prepareQrData(final QrCodeConfig config) {
         // Get the raw content
         String qrData = StringUtils.trim(config.getData());
-
         // If compression enabled then compress
         if (config.isCompressDigitalLink()) {
             qrData = compressor.compressGS1DigitalLink(qrData, true, true);
         }
-
         // If uppercase is enabled then convert to uppercase
         if (config.isCompressWithUppercase()) {
             qrData = StringUtils.upperCase(qrData);
         }
-
         return qrData;
     }
-
 
     /**
      * Writes an image to a byte array in the requested format.
@@ -223,7 +195,6 @@ public class QrCodeGenerator {
             final String formatName = StringUtils.substringAfter(mimeType, "/");
             final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             boolean written = ImageIO.write(image, formatName, byteArrayOutputStream);
-
             if (!written) {
                 // Writers for formats without alpha support (JPEG, BMP) reject ARGB images and
                 // return false without output: flatten onto an opaque canvas and retry rather
@@ -236,11 +207,9 @@ public class QrCodeGenerator {
                 opaqueGraphics.dispose();
                 written = ImageIO.write(opaque, formatName, byteArrayOutputStream);
             }
-
             if (!written) {
                 throw new QrCodeGeneratorException("No ImageIO writer available for mime type: " + mimeType);
             }
-
             return byteArrayOutputStream.toByteArray();
         } catch (Exception e) {
             log.error("Error writing image to bytes: " + e.getMessage(), e);
@@ -251,10 +220,7 @@ public class QrCodeGenerator {
     /**
      * Helper to see if the module’s bounding box overlaps the center logo area
      */
-    private boolean doesOverlap(float left, float top,
-                                float right, float bottom,
-                                int logoX, int logoY,
-                                int logoW, int logoH) {
+    private boolean doesOverlap(float left, float top, float right, float bottom, int logoX, int logoY, int logoW, int logoH) {
         if (right < logoX) return false; // module is left of logo
         if (left > logoX + logoW) return false; // module is right of logo
         if (bottom < logoY) return false; // module is above logo
@@ -264,20 +230,16 @@ public class QrCodeGenerator {
     /**
      * Creates either a linear or radial gradient paint based on user preferences.
      */
-    private Paint createGradientPaint(final float x2, final float y2,
-                                      final Color color1, final Color color2,
-                                      final boolean useRadialGradient) {
+    private Paint createGradientPaint(final float x2, final float y2, final Color color1, final Color color2, final boolean useRadialGradient) {
         // Check if a radial gradient is requested.
         if (useRadialGradient) {
-            final float cx = ((float) 0 + x2) / 2f; // Calculate the center x-coordinate of the radial gradient.
-            final float cy = ((float) 0 + y2) / 2f; // Calculate the center y-coordinate of the radial gradient.
-            final float radius = Math.max(x2 - (float) 0, y2 - (float) 0) / 2f; // Calculate the radius of the radial gradient.
-            final float[] dist = {0f, 1f}; // Define the distribution of colors in the gradient (start and end).
+            final float cx = ((float) 0 + x2) / 2.0F; // Calculate the center x-coordinate of the radial gradient.
+            final float cy = ((float) 0 + y2) / 2.0F; // Calculate the center y-coordinate of the radial gradient.
+            final float radius = Math.max(x2 - (float) 0, y2 - (float) 0) / 2.0F; // Calculate the radius of the radial gradient.
+            final float[] dist = {0.0F, 1.0F}; // Define the distribution of colors in the gradient (start and end).
             final Color[] colors = {color1, color2}; // Define the colors for the gradient.
-
             // Create and return a RadialGradientPaint object.
-            return new RadialGradientPaint(
-                    cx, cy, radius, dist, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE);
+            return new RadialGradientPaint(cx, cy, radius, dist, colors, MultipleGradientPaint.CycleMethod.NO_CYCLE);
         } else {
             // Create and return a Linear GradientPaint object. Linear gradient from top-left to bottom-right
             return new GradientPaint((float) 0, (float) 0, color1, x2, y2, color2);
@@ -287,51 +249,34 @@ public class QrCodeGenerator {
     /**
      * Checks if a module belongs to one of the 3 standard finder patterns (7x7).
      */
-    private boolean isInFinderPattern(final int x, final int y,
-                                      final int matrixWidth, final int matrixHeight) {
+    private boolean isInFinderPattern(final int x, final int y, final int matrixWidth, final int matrixHeight) {
         // Define the size of the finder pattern (7x7).
         final int finderSize = 7;
-
         // Check if the module is within the top-left finder pattern.
         if (x < finderSize && y < finderSize) {
             return true;
         }
-
         // Check if the module is within the top-right finder pattern.
         if (x >= matrixWidth - finderSize && y < finderSize) {
             return true;
         }
-
         // Check if the module is within the bottom-left finder pattern.
         return x < finderSize && y >= matrixHeight - finderSize;
-
         // If none of the finder pattern conditions are met, return false.
     }
 
     /**
      * Draws a single module (pixel) with optional shadow and custom shape.
      */
-    private void drawSingleModule(final Graphics2D g2d, final int x, final int y,
-                                  final float moduleSizeX, final float moduleSizeY, final float moduleSize,
-                                  final QrCodeConfig.ModuleShape shape, final boolean drawShadows,
-                                  final Color shadowColor, final float shadowOffsetPct, final Paint modulePaint) {
-
+    private void drawSingleModule(final Graphics2D g2d, final int x, final int y, final float moduleSizeX, final float moduleSizeY, final float moduleSize, final QrCodeConfig.ModuleShape shape, final boolean drawShadows, final Color shadowColor, final float shadowOffsetPct, final Paint modulePaint) {
         final float px = x * moduleSizeX;
         final float py = y * moduleSizeY;
-
         // Check if shadows should be drawn and a shadow color is provided.
         if (drawShadows && shadowColor != null) {
             g2d.setColor(shadowColor); // Set the color for the shadow.
-
             final float offset = moduleSize * shadowOffsetPct; // Calculate the offset for the shadow.
-            createShape(
-                    g2d,
-                    px + offset,
-                    py + offset,
-                    moduleSize,
-                    shape); // Create & fill the shape for the shadow.
+            createShape(g2d, px + offset, py + offset, moduleSize, shape); // Create & fill the shape for the shadow.
         }
-
         // Fill the module with the gradient or paint
         g2d.setPaint(modulePaint); // Set the paint for the module.
         createShape(g2d, px, py, moduleSize, shape); // Create & fill the shape for the module.
@@ -340,10 +285,7 @@ public class QrCodeGenerator {
     /**
      * Draws the 7x7 finder pattern block by iterating each module in that region.
      */
-    private void drawFinderPattern(final Graphics2D g2d, final BitMatrix matrix,
-                                   final int startX, final int startY,
-                                   final float moduleSize, final QrCodeConfig config,
-                                   final Paint finderPaint) {
+    private void drawFinderPattern(final Graphics2D g2d, final BitMatrix matrix, final int startX, final int startY, final float moduleSize, final QrCodeConfig config, final Paint finderPaint) {
         // Iterate through each row of the finder pattern.
         for (int row = 0; row < 7; row++) {
             // Iterate through each column of the finder pattern.
@@ -352,14 +294,12 @@ public class QrCodeGenerator {
                 if (matrix.get(startX + col, startY + row)) {
                     float px = (startX + col) * ((float) config.getQrWidth() / matrix.getWidth()); // Calculate the pixel x-coordinate of the module.
                     float py = (startY + row) * ((float) config.getQrHeight() / matrix.getHeight()); // Calculate the pixel y-coordinate of the module.
-
                     // Check if shadows should be drawn.
                     if (config.isDrawShadows() && config.isDrawFinderGradient() && config.getShadowColor() != null) {
                         g2d.setColor(config.getShadowColor()); // Set the color for the shadow.
                         float offset = moduleSize * config.getShadowOffsetPct(); // Calculate the offset for the shadow.
                         createShape(g2d, px + offset, py + offset, moduleSize, config.getModuleShape()); // Create & fill the shape for the shadow.
                     }
-
                     // Main fill
                     g2d.setPaint(finderPaint); // Set the paint for the module.
                     createShape(g2d, px, py, moduleSize, config.getModuleShape()); // Create & fill the shape for the module.
@@ -371,9 +311,7 @@ public class QrCodeGenerator {
     /**
      * Creates a shape for the module based on the chosen CustomShape (SQUARE, ROUNDED_RECT, CIRCLE, etc.).
      */
-    private void createShape(final Graphics2D g2d, final float x, final float y,
-                             final float moduleSize, final QrCodeConfig.ModuleShape shape) {
-
+    private void createShape(final Graphics2D g2d, final float x, final float y, final float moduleSize, final QrCodeConfig.ModuleShape shape) {
         switch (shape) {
             // If the shape is SQUARE, create a Rectangle2D.Float.
             case SQUARE -> {
@@ -384,7 +322,7 @@ public class QrCodeGenerator {
             // If the shape is ROUNDED_RECT, create a RoundRectangle2D.Float.
             case ROUNDED_RECT -> {
                 // Calculate the arc size for the rounded corners (30% of the size).
-                final float arc = moduleSize * 0.3f;
+                final float arc = moduleSize * 0.3F;
                 final RoundRectangle2D.Float roundRectAngle2d = new RoundRectangle2D.Float(x, y, moduleSize, moduleSize, arc, arc);
                 g2d.fill(roundRectAngle2d);
             }
@@ -404,10 +342,9 @@ public class QrCodeGenerator {
             }
             case BARCODE -> {
                 // Create BARCODE shape (vertical strip in the middle)
-                float lineWidth = moduleSize * 0.4f;
-                float offsetX = x + (moduleSize - lineWidth) / 2f;
+                float lineWidth = moduleSize * 0.4F;
+                float offsetX = x + (moduleSize - lineWidth) / 2.0F;
                 g2d.fillRect(Math.round(offsetX), Math.round(y), Math.round(lineWidth), Math.round(moduleSize));
-
             }
             case LETTER -> {
                 // Custom NAME shape (if not provided draw letter A)
@@ -421,13 +358,11 @@ public class QrCodeGenerator {
                 final double outerRadius = moduleSize / 2 * 1.1;
                 final double innerRadius = outerRadius * 0.5;
                 final int points = 4;
-
                 for (int i = 0; i < points * 2; i++) {
                     final double angle = Math.PI / points * i;
                     final double radius = (i % 2 == 0) ? outerRadius : innerRadius;
                     final double dx = centerX + Math.cos(angle) * radius;
                     final double dy = centerY + Math.sin(angle) * radius;
-
                     if (i == 0) {
                         star.moveTo(dx, dy);
                     } else {
@@ -477,14 +412,11 @@ public class QrCodeGenerator {
     /**
      * Draw logo image (keeps proportions and center).
      */
-    private void drawLogo(final Graphics2D g2d, final String logoResourceUrl,
-                          final int x, final int y,
-                          final int w, final int h) {
+    private void drawLogo(final Graphics2D g2d, final String logoResourceUrl, final int x, final int y, final int w, final int h) {
         try {
             BufferedImage logo;
             log.debug("reading logo from {}", logoResourceUrl);
             final URI logoUri = new URI(logoResourceUrl);
-
             if (!logoUri.isAbsolute()) {
                 log.debug("use logo from relative file path or classpath");
                 // Treat as a relative file path, falling back to a classpath resource. The
@@ -519,7 +451,6 @@ public class QrCodeGenerator {
                     logo = ImageIO.read(logoUrl);
                 }
             }
-
             if (logo != null) {
                 g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
                 g2d.drawImage(logo, x, y, w, h, null); // Draw the logo onto the blank region
@@ -538,23 +469,20 @@ public class QrCodeGenerator {
     private byte[] writeHRIData(final URL digitalLinkURL, final QrCodeConfig config, final BufferedImage qrImage) {
         // All HRI paddings and font-size proportional to QR height/width
         final float hriFontSize = 12; // Font size for HRI text
-        final int hriPaddingX = Math.round(config.getQrWidth() * 0.05f); // Padding on left/right of HRI text
+        final int hriPaddingX = Math.round(config.getQrWidth() * 0.05F); // Padding on left/right of HRI text
         final int hriAvailableWidth = config.getQrWidth() - 2 * hriPaddingX; // Available width for HRI text
-        final int hriPaddingTop = Math.round(config.getMargin() * 0.045f); // Padding above HRI text
-
+        final int hriPaddingTop = Math.round(config.getMargin() * 0.045F); // Padding above HRI text
         // Get HRI font metrics
         final BufferedImage tempImg = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
         final Graphics2D tempG = tempImg.createGraphics();
         tempG.setFont(OCR_B_FONT.deriveFont(hriFontSize));
         final FontMetrics hriFM = tempG.getFontMetrics();
         tempG.dispose();
-
         // Parse and Format HRI lines to fit in available width
         final Map<String, String> hriData = GS1DigitalLinkParser.parse(digitalLinkURL);
         final List<String> hriLines = formatHRIForQr(hriData, config.getQrWidth(), qrImage.createGraphics().getFontMetrics(OCR_B_FONT));
         final int hriLineHeight = hriFM.getHeight();
         final int hriBlockHeight = Math.max(1, hriPaddingTop + hriLines.size() * hriLineHeight);
-
         // Create HRI image
         final BufferedImage hriImage = new BufferedImage(config.getQrWidth(), hriBlockHeight, BufferedImage.TYPE_INT_RGB);
         final Graphics2D hriG = hriImage.createGraphics();
@@ -562,7 +490,6 @@ public class QrCodeGenerator {
         hriG.fillRect(0, 0, config.getQrWidth(), hriBlockHeight);
         hriG.setFont(OCR_B_FONT.deriveFont(hriFontSize));
         hriG.setColor(Color.BLACK);
-
         // Draw each line of HRI text centered within the available width
         int hriY = hriPaddingTop + hriFM.getAscent();
         for (String line : hriLines) {
@@ -577,7 +504,6 @@ public class QrCodeGenerator {
             hriY += hriLineHeight;
         }
         hriG.dispose();
-
         // Combine QR and HRI images vertically
         int combinedHeight = config.getQrHeight() + hriBlockHeight;
         BufferedImage combinedImage = new BufferedImage(config.getQrWidth(), combinedHeight, BufferedImage.TYPE_INT_RGB);
@@ -585,7 +511,6 @@ public class QrCodeGenerator {
         cg.drawImage(qrImage, 0, 0, null);
         cg.drawImage(hriImage, 0, config.getQrHeight(), null);
         cg.dispose();
-
         // Write the combined image to bytes and return
         return writeImageToBytes(combinedImage, config.getMimeType());
     }
@@ -593,20 +518,15 @@ public class QrCodeGenerator {
     /**
      * Format GS1 HRI lines so each fits within maxLineWidth.
      */
-    private List<String> formatHRIForQr(final Map<String, String> gs1Data,
-                                        final int availableLineWidth,
-                                        final FontMetrics fm) {
+    private List<String> formatHRIForQr(final Map<String, String> gs1Data, final int availableLineWidth, final FontMetrics fm) {
         final List<String> formattedHRI = new ArrayList<>();
         final StringBuilder currentLine = new StringBuilder();
         final int spaceWidth = fm.stringWidth(" "); // Width of a space character
-
         for (Map.Entry<String, String> entry : gs1Data.entrySet()) {
             final String formattedPair = "(" + entry.getKey() + ")" + entry.getValue();
             final int pairWidth = fm.stringWidth(formattedPair);
-
             // If the current line is empty or adding the new pair doesn't exceed max width, append it
-            if (currentLine.length() == 0 ||
-                    fm.stringWidth(currentLine.toString()) + spaceWidth + pairWidth <= availableLineWidth) {
+            if (currentLine.length() == 0 || fm.stringWidth(currentLine.toString()) + spaceWidth + pairWidth <= availableLineWidth) {
                 // If text fits, add it to the current line and Add a space before appending
                 if (currentLine.length() > 0) currentLine.append(" ");
                 currentLine.append(formattedPair);
@@ -617,7 +537,6 @@ public class QrCodeGenerator {
                 currentLine.append(formattedPair); // Start a new line with the current pair
             }
         }
-
         // add the remaining line
         if (currentLine.length() > 0) formattedHRI.add(currentLine.toString());
         return formattedHRI;

--- a/qrcode-generator/core/src/main/java/io/openepcis/qrcode/generator/util/QrCodeConstants.java
+++ b/qrcode-generator/core/src/main/java/io/openepcis/qrcode/generator/util/QrCodeConstants.java
@@ -1,9 +1,5 @@
 package io.openepcis.qrcode.generator.util;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class QrCodeConstants {
     public static final String[] ACCEPT_HEADER = {"image/png", "image/jpeg", "image/jpg", "image/gif", "image/bmp", "image/tiff"};
     public static final String API_TAG_NAME = "QR Code Generator";
@@ -21,7 +17,7 @@ public class QrCodeConstants {
     public static final String GS1_IDENTIFIER_DOMAIN = "https://id.gs1.org/";
     public static final String GET_API_PATH_PARAMETER_DESCRIPTION = "Identifiers to be encoded in generated QR code.";
     public static final String API_ACCEPT_PARAMETER_DESCRIPTION = "Accept header to control image media type (defaults to image/png if not provided).";
-    public static final String API_DESIGN_PRESET_PARAMETER_DESCRIPTION = "Specifies the pre-defined design preset associated with the QR code configuration. This may trigger custom defaults if set to a value like 'openepcis, gs1, etc.'.";
+    public static final String API_DESIGN_PRESET_PARAMETER_DESCRIPTION = "Specifies the pre-defined design preset associated with the QR code configuration. This may trigger custom defaults if set to a value like \'openepcis, gs1, etc.\'.";
     public static final String API_HRI_PARAMETER_DESCRIPTION = "Specifies whether the Human Readable Interpretation (HRI) should be included in the QR code. Defaults to false if not specified.";
     public static final String API_COMPRESSED_PARAMETER_DESCRIPTION = "Specifies whether DL URL should be compressed before generating QR Code. Defaults to false if not specified and if enabled cannot generate HRI.";
     public static final String OPTIONS_API_OPERATION_SUMMARY = "Retrieve available QR code generation options";
@@ -32,4 +28,7 @@ public class QrCodeConstants {
     public static final String OPTIONS_API_RESPONSE_ERROR_DESCRIPTION = "Internal server error retrieving the options.";
     public static final String GET_DESIGN_PRESET_API_OPERATION_SUMMARY = "List all available QR code design presets";
     public static final String GET_DESIGN_PRESET_API_OPERATION_DESCRIPTION = "Fetches a list of predefined QR code design presets (`QrCodeConfig`). Each preset includes default styling attributes such as dimensions, gradient colors, background, and logo positioning, which can be applied when generating QR codes.";
+
+    private QrCodeConstants() {
+    }
 }

--- a/qrcode-generator/core/src/test/java/io/openepcis/qrcode/generator/QrCodeGeneratorTest.java
+++ b/qrcode-generator/core/src/test/java/io/openepcis/qrcode/generator/QrCodeGeneratorTest.java
@@ -10,7 +10,6 @@
  */
 package io.openepcis.qrcode.generator;
 
-import lombok.extern.slf4j.Slf4j;
 
 import java.awt.*;
 import java.io.IOException;
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-@Slf4j
 public class QrCodeGeneratorTest {
 
     private QrCodeGenerator barCodeGenerator;

--- a/qrcode-generator/extensions/src/test/java/io/openepcis/qrcode/generator/QrCodeGeneratorTest.java
+++ b/qrcode-generator/extensions/src/test/java/io/openepcis/qrcode/generator/QrCodeGeneratorTest.java
@@ -1,6 +1,5 @@
 package io.openepcis.qrcode.generator;
 
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -8,7 +7,6 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-@Slf4j
 public class QrCodeGeneratorTest {
 
     private QrCodeGenerator barCodeGenerator;

--- a/qrcode-generator/quarkus/quarkus-app/src/main/java/io/openepcis/qrcode/generator/exception/ExceptionMapper.java
+++ b/qrcode-generator/quarkus/quarkus-app/src/main/java/io/openepcis/qrcode/generator/exception/ExceptionMapper.java
@@ -1,13 +1,11 @@
 package io.openepcis.qrcode.generator.exception;
 
 import io.openepcis.qrcode.generator.exception.QrCodeGeneratorException;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
-@Slf4j
 public class ExceptionMapper {
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExceptionMapper.class);
     public static final String EXCEPTION_OCCURRED_DURING_CREATION_OF_QR_CODE = "Exception occurred during creation of QR code based on provided config";
 
     @ServerExceptionMapper
@@ -43,13 +41,88 @@ public class ExceptionMapper {
         return RestResponse.status(RestResponse.Status.BAD_REQUEST, responseBody);
     }
 
-
     // Inner class for ProblemResponseBody
-    @Data
     static class ProblemResponseBody {
         private String type;
         private String title;
         private int status;
         private String detail;
+
+        public ProblemResponseBody() {
+        }
+
+        public String getType() {
+            return this.type;
+        }
+
+        public String getTitle() {
+            return this.title;
+        }
+
+        public int getStatus() {
+            return this.status;
+        }
+
+        public String getDetail() {
+            return this.detail;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public void setStatus(int status) {
+            this.status = status;
+        }
+
+        public void setDetail(String detail) {
+            this.detail = detail;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (!(o instanceof ExceptionMapper.ProblemResponseBody)) return false;
+            ExceptionMapper.ProblemResponseBody other = (ExceptionMapper.ProblemResponseBody) o;
+            if (!other.canEqual((Object) this)) return false;
+            if (this.getStatus() != other.getStatus()) return false;
+            Object this$type = this.getType();
+            Object other$type = other.getType();
+            if (this$type == null ? other$type != null : !this$type.equals(other$type)) return false;
+            Object this$title = this.getTitle();
+            Object other$title = other.getTitle();
+            if (this$title == null ? other$title != null : !this$title.equals(other$title)) return false;
+            Object this$detail = this.getDetail();
+            Object other$detail = other.getDetail();
+            if (this$detail == null ? other$detail != null : !this$detail.equals(other$detail)) return false;
+            return true;
+        }
+
+        protected boolean canEqual(Object other) {
+            return other instanceof ExceptionMapper.ProblemResponseBody;
+        }
+
+        @Override
+        public int hashCode() {
+            int PRIME = 59;
+            int result = 1;
+            result = result * PRIME + this.getStatus();
+            Object $type = this.getType();
+            result = result * PRIME + ($type == null ? 43 : $type.hashCode());
+            Object $title = this.getTitle();
+            result = result * PRIME + ($title == null ? 43 : $title.hashCode());
+            Object $detail = this.getDetail();
+            result = result * PRIME + ($detail == null ? 43 : $detail.hashCode());
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "ExceptionMapper.ProblemResponseBody(type=" + this.getType() + ", title=" + this.getTitle() + ", status=" + this.getStatus() + ", detail=" + this.getDetail() + ")";
+        }
     }
 }

--- a/qrcode-generator/rest-api/src/main/java/io/openepcis/qrcode/generator/resource/QrCodeGeneratorResource.java
+++ b/qrcode-generator/rest-api/src/main/java/io/openepcis/qrcode/generator/resource/QrCodeGeneratorResource.java
@@ -20,44 +20,33 @@ import io.smallrye.mutiny.Uni;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Response;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
-@RequiredArgsConstructor
 public class QrCodeGeneratorResource implements QrCodeGeneratorApi {
-
     private final QrCodeService qrCodeService;
-
     @ConfigProperty(name = "gs1.digital-link.base-url", defaultValue = QrCodeConstants.GS1_IDENTIFIER_DOMAIN)
     String baseUrl;
 
-
     // Method to generate the QR Code based on user provided specifications as QrCodeConfig and return
     @Override
-    public Uni<Response> generate(@BeanParam QrCodeGenerationParams params,
-                                        QrCodeConfig qrConfig) {
-
+    public Uni<Response> generate(@BeanParam QrCodeGenerationParams params, QrCodeConfig qrConfig) {
         // delegate to service which applies params (Accept, designPreset, hri, compressed)
         return qrCodeService.generate(params, qrConfig);
     }
 
     // Method to generate the QR Code based on a Digital Link path by adding domain and return
     @Override
-    public Uni<Response> fetch(@BeanParam QrCodeGenerationParams params,
-                               @PathParam("linkPath") String linkPath) {
+    public Uni<Response> fetch(@BeanParam QrCodeGenerationParams params, @PathParam("linkPath") String linkPath) {
         if (StringUtils.isBlank(linkPath)) {
             throw new QrCodeGeneratorException("Cannot generate QR Code : Invalid Digital Link path, cannot be blank.");
         }
-
         String dlUrl;
         try {
             final URI uri = new URI(linkPath);
-
             // If linkPath is absolute, use as-is without appending baseUrl
             if (uri.isAbsolute()) {
                 dlUrl = linkPath;
@@ -65,12 +54,10 @@ public class QrCodeGeneratorResource implements QrCodeGeneratorApi {
                 // Append baseUrl + normalized relative path
                 dlUrl = qrCodeService.normalizePathWithBaseUrl(baseUrl, linkPath);
             }
-
         } catch (URISyntaxException e) {
             // If URI is invalid then treat it as a relative path
             dlUrl = qrCodeService.normalizePathWithBaseUrl(baseUrl, linkPath);
         }
-
         final QrCodeConfig qrCodeConfig = QrCodeConfig.builder().data(dlUrl).build();
         return qrCodeService.generate(params, qrCodeConfig);
     }
@@ -78,16 +65,16 @@ public class QrCodeGeneratorResource implements QrCodeGeneratorApi {
     // Method to provide various QR code generation options like img/png, img/svg, etc.
     @Override
     public Uni<Response> options() {
-        return Uni.createFrom().item(
-                Response.ok()
-                        .header("Accept-Get", String.join(",", QrCodeConstants.ACCEPT_HEADER))
-                        .header("Accept-Post", String.join(",", QrCodeConstants.ACCEPT_HEADER)).build()
-        );
+        return Uni.createFrom().item(Response.ok().header("Accept-Get", String.join(",", QrCodeConstants.ACCEPT_HEADER)).header("Accept-Post", String.join(",", QrCodeConstants.ACCEPT_HEADER)).build());
     }
 
     // Method to list all available design presets for QR Code generation
     @Override
     public Uni<List<QrCodeConfig>> listDesignPresets() {
         return qrCodeService.listPresets();
+    }
+
+    public QrCodeGeneratorResource(QrCodeService qrCodeService) {
+        this.qrCodeService = qrCodeService;
     }
 }

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -35,18 +35,9 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
 
-        <!-- For Getter/Setter and other methods -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
         <dependency>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <groupId>jakarta.enterprise</groupId>
-        </dependency>
-        <dependency>
-            <artifactId>lombok</artifactId>
-            <groupId>org.projectlombok</groupId>
         </dependency>
         <dependency>
             <artifactId>junit-jupiter-api</artifactId>

--- a/utils/src/main/java/io/openepcis/digitallink/model/ApplicationIdentifier.java
+++ b/utils/src/main/java/io/openepcis/digitallink/model/ApplicationIdentifier.java
@@ -1,14 +1,7 @@
 package io.openepcis.digitallink.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.List;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class ApplicationIdentifier {
     private String title;
     private String label;
@@ -20,5 +13,175 @@ public class ApplicationIdentifier {
     private String checkDigit;
     private String regex;
     private List<String> qualifiers;
-}
 
+    public String getTitle() {
+        return this.title;
+    }
+
+    public String getLabel() {
+        return this.label;
+    }
+
+    public String getShortcode() {
+        return this.shortcode;
+    }
+
+    public String getAi() {
+        return this.ai;
+    }
+
+    public String getFormat() {
+        return this.format;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public Boolean getFixedLength() {
+        return this.fixedLength;
+    }
+
+    public String getCheckDigit() {
+        return this.checkDigit;
+    }
+
+    public String getRegex() {
+        return this.regex;
+    }
+
+    public List<String> getQualifiers() {
+        return this.qualifiers;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public void setShortcode(String shortcode) {
+        this.shortcode = shortcode;
+    }
+
+    public void setAi(String ai) {
+        this.ai = ai;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setFixedLength(Boolean fixedLength) {
+        this.fixedLength = fixedLength;
+    }
+
+    public void setCheckDigit(String checkDigit) {
+        this.checkDigit = checkDigit;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    public void setQualifiers(List<String> qualifiers) {
+        this.qualifiers = qualifiers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ApplicationIdentifier)) return false;
+        ApplicationIdentifier other = (ApplicationIdentifier) o;
+        if (!other.canEqual((Object) this)) return false;
+        Object this$fixedLength = this.getFixedLength();
+        Object other$fixedLength = other.getFixedLength();
+        if (this$fixedLength == null ? other$fixedLength != null : !this$fixedLength.equals(other$fixedLength)) return false;
+        Object this$title = this.getTitle();
+        Object other$title = other.getTitle();
+        if (this$title == null ? other$title != null : !this$title.equals(other$title)) return false;
+        Object this$label = this.getLabel();
+        Object other$label = other.getLabel();
+        if (this$label == null ? other$label != null : !this$label.equals(other$label)) return false;
+        Object this$shortcode = this.getShortcode();
+        Object other$shortcode = other.getShortcode();
+        if (this$shortcode == null ? other$shortcode != null : !this$shortcode.equals(other$shortcode)) return false;
+        Object this$ai = this.getAi();
+        Object other$ai = other.getAi();
+        if (this$ai == null ? other$ai != null : !this$ai.equals(other$ai)) return false;
+        Object this$format = this.getFormat();
+        Object other$format = other.getFormat();
+        if (this$format == null ? other$format != null : !this$format.equals(other$format)) return false;
+        Object this$type = this.getType();
+        Object other$type = other.getType();
+        if (this$type == null ? other$type != null : !this$type.equals(other$type)) return false;
+        Object this$checkDigit = this.getCheckDigit();
+        Object other$checkDigit = other.getCheckDigit();
+        if (this$checkDigit == null ? other$checkDigit != null : !this$checkDigit.equals(other$checkDigit)) return false;
+        Object this$regex = this.getRegex();
+        Object other$regex = other.getRegex();
+        if (this$regex == null ? other$regex != null : !this$regex.equals(other$regex)) return false;
+        Object this$qualifiers = this.getQualifiers();
+        Object other$qualifiers = other.getQualifiers();
+        if (this$qualifiers == null ? other$qualifiers != null : !this$qualifiers.equals(other$qualifiers)) return false;
+        return true;
+    }
+
+    protected boolean canEqual(Object other) {
+        return other instanceof ApplicationIdentifier;
+    }
+
+    @Override
+    public int hashCode() {
+        int PRIME = 59;
+        int result = 1;
+        Object $fixedLength = this.getFixedLength();
+        result = result * PRIME + ($fixedLength == null ? 43 : $fixedLength.hashCode());
+        Object $title = this.getTitle();
+        result = result * PRIME + ($title == null ? 43 : $title.hashCode());
+        Object $label = this.getLabel();
+        result = result * PRIME + ($label == null ? 43 : $label.hashCode());
+        Object $shortcode = this.getShortcode();
+        result = result * PRIME + ($shortcode == null ? 43 : $shortcode.hashCode());
+        Object $ai = this.getAi();
+        result = result * PRIME + ($ai == null ? 43 : $ai.hashCode());
+        Object $format = this.getFormat();
+        result = result * PRIME + ($format == null ? 43 : $format.hashCode());
+        Object $type = this.getType();
+        result = result * PRIME + ($type == null ? 43 : $type.hashCode());
+        Object $checkDigit = this.getCheckDigit();
+        result = result * PRIME + ($checkDigit == null ? 43 : $checkDigit.hashCode());
+        Object $regex = this.getRegex();
+        result = result * PRIME + ($regex == null ? 43 : $regex.hashCode());
+        Object $qualifiers = this.getQualifiers();
+        result = result * PRIME + ($qualifiers == null ? 43 : $qualifiers.hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicationIdentifier(title=" + this.getTitle() + ", label=" + this.getLabel() + ", shortcode=" + this.getShortcode() + ", ai=" + this.getAi() + ", format=" + this.getFormat() + ", type=" + this.getType() + ", fixedLength=" + this.getFixedLength() + ", checkDigit=" + this.getCheckDigit() + ", regex=" + this.getRegex() + ", qualifiers=" + this.getQualifiers() + ")";
+    }
+
+    public ApplicationIdentifier(String title, String label, String shortcode, String ai, String format, String type, Boolean fixedLength, String checkDigit, String regex, List<String> qualifiers) {
+        this.title = title;
+        this.label = label;
+        this.shortcode = shortcode;
+        this.ai = ai;
+        this.format = format;
+        this.type = type;
+        this.fixedLength = fixedLength;
+        this.checkDigit = checkDigit;
+        this.regex = regex;
+        this.qualifiers = qualifiers;
+    }
+
+    public ApplicationIdentifier() {
+    }
+}

--- a/utils/src/main/java/io/openepcis/digitallink/utils/DefaultGCPLengthProvider.java
+++ b/utils/src/main/java/io/openepcis/digitallink/utils/DefaultGCPLengthProvider.java
@@ -16,9 +16,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.openepcis.core.exception.UnsupportedGS1IdentifierException;
 import io.openepcis.core.exception.UrnDLTransformationException;
 import io.openepcis.digitallink.utils.resolver.GCPLengthResolverManager;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -31,22 +29,18 @@ import java.util.regex.Pattern;
  * Thread-safe singleton that resolves GS1 company-prefix lengths
  * from <code>gcpprefixformatlist.json</code>.
  */
-@Slf4j
 public final class DefaultGCPLengthProvider implements GCPLengthProvider {
-
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultGCPLengthProvider.class);
     /* ------------------------------------------------------------------ *
      *  Static initialisation                                              *
      * ------------------------------------------------------------------ */
-
     private static final String RESOURCE = "/gcpprefixformatlist.json";
     private static final String CUSTOM_RESOURCE = "/gcpprefixformatlist-custom.json";
     private static final String NO_GCP_HINT = "Visit GEPIR (https://gepir.gs1.org/) or contact your GS1 MO.";
-
     /**
      * Identifiers whose full value is already a GCP.
      */
     private static final Set<String> PREFIXES_WITH_GCP = Set.of("/8010/", "/255/", "/253/", "/8004/", "/401/", "/402/", "/8018/", "/8017/", "/417/", "/414/");
-
     /**
      * Immutable list sorted by <em>longest prefix first</em> for fast
      * longest-match scanning.
@@ -61,7 +55,6 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
 
     private static List<Entry> loadPrefixEntries() {
         final List<Entry> list = loadFromResource(RESOURCE, true);
-
         // Merge custom overlay entries if present on classpath
         try (InputStream customIn = DefaultGCPLengthProvider.class.getResourceAsStream(CUSTOM_RESOURCE)) {
             if (customIn != null) {
@@ -72,15 +65,12 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
         } catch (Exception e) {
             log.warn("Failed to load custom GCP prefixes from {}: {}", CUSTOM_RESOURCE, e.getMessage());
         }
-
         list.sort(Comparator.comparingInt((Entry e) -> e.prefix().length()).reversed().thenComparing(Entry::prefix));
         return List.copyOf(list);
     }
 
     private static List<Entry> loadFromResource(String resource, boolean required) {
-        try (InputStream in = required
-                ? Objects.requireNonNull(DefaultGCPLengthProvider.class.getResourceAsStream(resource), resource + " not found on classpath")
-                : DefaultGCPLengthProvider.class.getResourceAsStream(resource)) {
+        try (InputStream in = required ? Objects.requireNonNull(DefaultGCPLengthProvider.class.getResourceAsStream(resource), resource + " not found on classpath") : DefaultGCPLengthProvider.class.getResourceAsStream(resource)) {
             if (in == null) return new ArrayList<>();
             return loadFromResource(in);
         } catch (IOException e) {
@@ -92,7 +82,6 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
     private static List<Entry> loadFromResource(InputStream in) throws IOException {
         final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
         final JsonNode root = mapper.readTree(in).path("GCPPrefixFormatList").path("entry");
-
         final List<Entry> list = new ArrayList<>(root.size());
         for (JsonNode n : root) {
             list.add(new Entry(n.get("prefix").asText(), n.get("gcpLength").asInt()));
@@ -103,11 +92,10 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
     /* ------------------------------------------------------------------ *
      *  Singleton boiler-plate                                             *
      * ------------------------------------------------------------------ */
-
     private static final DefaultGCPLengthProvider INSTANCE = new DefaultGCPLengthProvider();
 
     private DefaultGCPLengthProvider() {
-    }     // prevent external instantiation
+    } // prevent external instantiation
 
     public static DefaultGCPLengthProvider getInstance() {
         return INSTANCE;
@@ -116,7 +104,6 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
     /* ------------------------------------------------------------------ *
      *  Public API                                                         *
      * ------------------------------------------------------------------ */
-
     /**
      * Resolve the GCP length for a full Digital Link URI.
      *
@@ -128,11 +115,9 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
         if (StringUtils.isBlank(gs1DigitalLinkURI) || gs1DigitalLinkURI.contains("urn:")) {
             throw new UnsupportedGS1IdentifierException("GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT);
         }
-
         // pattern: /<digits>/…  or  …/<digits>/…
         final Pattern p = Pattern.compile("(/|^)(\\d+/|/\\d+/)([^/]+)");
         final Matcher m = p.matcher(gs1DigitalLinkURI);
-
         if (m.find()) {
             final String prefix = m.group(2).startsWith("/") ? m.group(2) : "/" + m.group(2);
             final String identifier = m.group(3);
@@ -147,12 +132,10 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
     public int getGcpLength(final String gs1DigitalLinkURI, String identifier, final String gs1IdentifierPrefix) {
         // Save original identifier before GTIN stripping (needed for SPI/verifier)
         final String originalIdentifier = identifier;
-
         // GTINs: ignore first digit unless prefix itself embeds full GCP
         if (!PREFIXES_WITH_GCP.contains(gs1IdentifierPrefix) && identifier.length() > 13) {
             identifier = identifier.substring(1);
         }
-
         // Step 1: Static prefix table lookup
         for (Entry e : PREFIX_ENTRIES) {
             if (identifier.startsWith(e.prefix())) {
@@ -163,7 +146,6 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
                 break;
             }
         }
-
         // Step 2: SPI-based resolution (e.g. Verified by GS1) - If applicable find from there
         final GCPLengthResolverManager resolverManager = GCPLengthResolverManager.getInstance();
         if (resolverManager.hasResolvers()) {
@@ -177,7 +159,6 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
                 log.warn("SPI GCP length resolution failed for {}: {}", originalIdentifier, ex.getMessage());
             }
         }
-
         // Step 3: JVM property default
         // optional JVM override: -Dio.openepcis...defaultGcpLength=9
         final String prop = System.getProperty(getClass().getName() + ".defaultGcpLength");
@@ -188,34 +169,28 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
                 throw new IllegalArgumentException("Invalid default GCP length value: " + prop, nfe);
             }
         }
-
         throw new UnsupportedGS1IdentifierException("GCP length not found for Digital Link URI: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT);
     }
 
     /* ------------------------------------------------------------------ *
      *  Async Public API                                                   *
      * ------------------------------------------------------------------ */
-
     /**
      * Asynchronous variant of {@link #getGcpLength(String)} — never blocks the calling thread.
      */
     @Override
     public CompletionStage<Integer> getGcpLengthAsync(final String gs1DigitalLinkURI) {
         if (StringUtils.isBlank(gs1DigitalLinkURI) || gs1DigitalLinkURI.contains("urn:")) {
-            return CompletableFuture.failedFuture(
-                    new UnsupportedGS1IdentifierException("GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT));
+            return CompletableFuture.failedFuture(new UnsupportedGS1IdentifierException("GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT));
         }
-
         final Pattern p = Pattern.compile("(/|^)(\\d+/|/\\d+/)([^/]+)");
         final Matcher m = p.matcher(gs1DigitalLinkURI);
-
         if (m.find()) {
             final String prefix = m.group(2).startsWith("/") ? m.group(2) : "/" + m.group(2);
             final String identifier = m.group(3);
             return getGcpLengthAsync(gs1DigitalLinkURI, identifier, prefix);
         }
-        return CompletableFuture.failedFuture(
-                new UnsupportedGS1IdentifierException("GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT));
+        return CompletableFuture.failedFuture(new UnsupportedGS1IdentifierException("GCP length not found for: " + gs1DigitalLinkURI + ". " + NO_GCP_HINT));
     }
 
     /**
@@ -224,11 +199,9 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
      */
     public CompletionStage<Integer> getGcpLengthAsync(final String gs1DigitalLinkURI, String identifier, final String gs1IdentifierPrefix) {
         final String originalIdentifier = identifier;
-
         if (!PREFIXES_WITH_GCP.contains(gs1IdentifierPrefix) && identifier.length() > 13) {
             identifier = identifier.substring(1);
         }
-
         // Step 1: Static prefix table lookup (fast, synchronous)
         for (Entry e : PREFIX_ENTRIES) {
             if (identifier.startsWith(e.prefix())) {
@@ -239,21 +212,18 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
                 break;
             }
         }
-
         // Step 2: SPI-based async resolution
         final GCPLengthResolverManager resolverManager = GCPLengthResolverManager.getInstance();
         if (resolverManager.hasResolvers()) {
-            return resolverManager.resolveAsync(originalIdentifier)
-                    .thenApply(spiResult -> {
-                        if (spiResult.isPresent()) {
-                            log.debug("GCP length resolved via SPI for identifier {}: {}", originalIdentifier, spiResult.getAsInt());
-                            return spiResult.getAsInt();
-                        }
-                        // Step 3: JVM property default
-                        return getDefaultGcpLength(gs1DigitalLinkURI);
-                    });
+            return resolverManager.resolveAsync(originalIdentifier).thenApply(spiResult -> {
+                if (spiResult.isPresent()) {
+                    log.debug("GCP length resolved via SPI for identifier {}: {}", originalIdentifier, spiResult.getAsInt());
+                    return spiResult.getAsInt();
+                }
+                // Step 3: JVM property default
+                return getDefaultGcpLength(gs1DigitalLinkURI);
+            });
         }
-
         // No resolvers — fall through to default
         try {
             return CompletableFuture.completedFuture(getDefaultGcpLength(gs1DigitalLinkURI));
@@ -280,7 +250,6 @@ public final class DefaultGCPLengthProvider implements GCPLengthProvider {
     /* ------------------------------------------------------------------ *
      *  Internal value object                                              *
      * ------------------------------------------------------------------ */
-
     private record Entry(String prefix, int len) {
     }
 }

--- a/utils/src/main/java/io/openepcis/digitallink/utils/GS1DigitalLinkParser.java
+++ b/utils/src/main/java/io/openepcis/digitallink/utils/GS1DigitalLinkParser.java
@@ -1,9 +1,6 @@
 package io.openepcis.digitallink.utils;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -12,15 +9,11 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GS1DigitalLinkParser {
-
     // match /<AI>/<value> in the path
     private static final Pattern PATH_PATTERN = Pattern.compile("/(\\d{2,4})/([^/]*)");
-
     // match <AI>=<value> in query string
     private static final Pattern QUERY_PATTERN = Pattern.compile("(\\d{2,4})=([^&]*)");
-
 
     /**
      * Parses GS1 identifiers and metadata from a Digital Link URL.
@@ -32,28 +25,22 @@ public class GS1DigitalLinkParser {
      * @param includeUrlMeta if true, adds "protocol" and "domain" entries
      * @return a Map (insertion-ordered) of extracted elements
      */
-    public static Map<String, String> parse(final URL digitalLink,
-                                            final boolean includeUrlMeta) {
+    public static Map<String, String> parse(final URL digitalLink, final boolean includeUrlMeta) {
         final LinkedHashMap<String, String> extractedData = new LinkedHashMap<>();
-
         // Optionally include protocol and domain
         if (includeUrlMeta) {
             extractedData.put("protocol", digitalLink.getProtocol());
             extractedData.put("domain", digitalLink.getHost());
             extractedData.put("port", String.valueOf(digitalLink.getPort() == -1 ? digitalLink.getDefaultPort() : digitalLink.getPort()));
         }
-
         // Extract path segments using the defined pattern
         final String path = digitalLink.getPath();
         final Matcher pathMatcher = PATH_PATTERN.matcher(path);
-
         while (pathMatcher.find()) {
             final String ai = pathMatcher.group(1);
             final String value = URLDecoder.decode(pathMatcher.group(2), StandardCharsets.UTF_8);
             extractedData.put(ai, value);
         }
-
-
         // Extract Query Parameters
         final String query = digitalLink.getQuery();
         if (StringUtils.isNotBlank(query)) {
@@ -64,7 +51,6 @@ public class GS1DigitalLinkParser {
                 extractedData.put(ai, value);
             }
         }
-
         return extractedData;
     }
 
@@ -73,5 +59,8 @@ public class GS1DigitalLinkParser {
      */
     public static Map<String, String> parse(final URL digitalLink) {
         return parse(digitalLink, false);
+    }
+
+    private GS1DigitalLinkParser() {
     }
 }

--- a/utils/src/main/java/io/openepcis/digitallink/utils/Gs1UriEscape.java
+++ b/utils/src/main/java/io/openepcis/digitallink/utils/Gs1UriEscape.java
@@ -10,27 +10,14 @@
  */
 package io.openepcis.digitallink.utils;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-
 import java.util.Map;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Gs1UriEscape {
-
     // EPC TDS "URI Form" triplets that each stand for ONE logical character. It contains both:
     //   CSET-82 (X): " % & / < > ?   ->  %22 %25 %26 %2F %3C %3E %3F
     //   CPI    (Y): # /             ->  %23 %2F
-    private static final Map<String, String> ESCAPES = Map.of(
-            "%22", "\"",
-            "%23", "#",
-            "%25", "%",
-            "%26", "&",
-            "%2F", "/",
-            "%3C", "<",
-            "%3E", ">",
-            "%3F", "?");
+    private static final Map<String, String> ESCAPES = Map.of("%22", "\"", "%23", "#", "%25", "%", "%26", "&", "%2F", "/", "%3C", "<", "%3E", ">", "%3F", "?");
 
     // Collapse escape triplets to logical characters
     public static String decode(final String value) {
@@ -38,12 +25,10 @@ public class Gs1UriEscape {
         if (StringUtils.isBlank(value) || !value.contains("%")) {
             return value;
         }
-
         String out = value;
         for (Map.Entry<String, String> e : ESCAPES.entrySet()) {
             // replace both the upper-case and lower-case versions of the escape triplet
-            out = out.replace(e.getKey(), e.getValue())
-                    .replace(e.getKey().toLowerCase(), e.getValue());
+            out = out.replace(e.getKey(), e.getValue()).replace(e.getKey().toLowerCase(), e.getValue());
         }
         return out;
     }
@@ -54,11 +39,9 @@ public class Gs1UriEscape {
         if (StringUtils.isBlank(value) || !value.contains("%")) {
             return value;
         }
-
         final StringBuilder out = new StringBuilder(value.length());
         for (int i = 0; i < value.length(); i++) {
             final char c = value.charAt(i);
-
             // A valid triplet needs '%' plus two hex digits following it
             if (c == '%' && i + 2 <= value.length() && isHex(value.charAt(i + 1)) && isHex(value.charAt(i + 2))) {
                 out.append((char) Integer.parseInt(value.substring(i + 1, i + 3), 16)); // decoded char
@@ -67,14 +50,14 @@ public class Gs1UriEscape {
                 out.append(c);
             }
         }
-
         return out.toString();
     }
 
     // True for a hexadecimal digit (both cases), used to recognise a %XX triplet
     private static boolean isHex(final char c) {
-        return (c >= '0' && c <= '9') ||
-                (c >= 'A' && c <= 'F') ||
-                (c >= 'a' && c <= 'f');
+        return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+    }
+
+    private Gs1UriEscape() {
     }
 }

--- a/utils/src/main/java/io/openepcis/digitallink/utils/resolver/GCPLengthResolverManager.java
+++ b/utils/src/main/java/io/openepcis/digitallink/utils/resolver/GCPLengthResolverManager.java
@@ -8,11 +8,7 @@
  * benelog GmbH & Co. KG reserves all rights not expressly granted herein,
  * including the right to sell licenses for using this work.
  */
-
 package io.openepcis.digitallink.utils.resolver;
-
-
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
@@ -21,9 +17,8 @@ import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-@Slf4j
 public class GCPLengthResolverManager {
-
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(GCPLengthResolverManager.class);
     private static GCPLengthResolverManager gcpLengthResolverManager;
     private final List<GCPLengthResolver> resolvers;
 
@@ -41,7 +36,6 @@ public class GCPLengthResolverManager {
     public static synchronized GCPLengthResolverManager newInstance() {
         return new GCPLengthResolverManager(ServiceLoader.load(GCPLengthResolver.class).stream().map(ServiceLoader.Provider::get).toList());
     }
-
 
     /**
      * Try each registered resolver in priority order. Returns the first successful (non-empty) result.
@@ -78,15 +72,12 @@ public class GCPLengthResolverManager {
                     return CompletableFuture.completedFuture(result);
                 }
                 try {
-                    return resolver.resolveAsync(identifier)
-                            .exceptionally(e -> {
-                                log.warn("GCPLengthResolver {} failed async for identifier {}: {}",
-                                        resolver.getClass().getSimpleName(), identifier, e.getMessage());
-                                return OptionalInt.empty();
-                            });
+                    return resolver.resolveAsync(identifier).exceptionally(e -> {
+                        log.warn("GCPLengthResolver {} failed async for identifier {}: {}", resolver.getClass().getSimpleName(), identifier, e.getMessage());
+                        return OptionalInt.empty();
+                    });
                 } catch (Exception e) {
-                    log.warn("GCPLengthResolver {} failed for identifier {}: {}",
-                            resolver.getClass().getSimpleName(), identifier, e.getMessage());
+                    log.warn("GCPLengthResolver {} failed for identifier {}: {}", resolver.getClass().getSimpleName(), identifier, e.getMessage());
                     return CompletableFuture.completedFuture(OptionalInt.empty());
                 }
             });

--- a/validator/core/src/main/java/io/openepcis/identifiers/validator/ValidationContext.java
+++ b/validator/core/src/main/java/io/openepcis/identifiers/validator/ValidationContext.java
@@ -1,31 +1,157 @@
 package io.openepcis.identifiers.validator;
 
-import lombok.Builder;
-import lombok.Value;
+public final class ValidationContext {
+    /**
+     * If true, enforce EPCIS‐compliance rules and validates GS1 AI against only EPCIS supported AI. Defaults to true.
+     */
+    private final boolean epcisCompliant;
+    /**
+     * If true, run the GS1 check-digit validation along with normal validation. Defaults to true.
+     */
+    private final boolean validateCheckDigit;
+    /**
+     * When present, validates for Digital-Link URI using this GCP length. Empty validates for URN mode.
+     */
+    private final Integer gcpLength;
 
-@Value
-@Builder
-public class ValidationContext {
+    public static ValidationContext defaultContext() {
+        return ValidationContext.builder().build();
+    }
+
+    private static boolean $default$epcisCompliant() {
+        return true;
+    }
+
+    private static boolean $default$validateCheckDigit() {
+        return true;
+    }
+
+    private static Integer $default$gcpLength() {
+        return null;
+    }
+
+    /**
+     * Creates a new {@code ValidationContext} instance.
+     *
+     * @param epcisCompliant If true, enforce EPCIS‐compliance rules and validates GS1 AI against only EPCIS supported AI. Defaults to true.
+     * @param validateCheckDigit If true, run the GS1 check-digit validation along with normal validation. Defaults to true.
+     * @param gcpLength When present, validates for Digital-Link URI using this GCP length. Empty validates for URN mode.
+     */
+    ValidationContext(boolean epcisCompliant, boolean validateCheckDigit, Integer gcpLength) {
+        this.epcisCompliant = epcisCompliant;
+        this.validateCheckDigit = validateCheckDigit;
+        this.gcpLength = gcpLength;
+    }
+
+
+    public static class ValidationContextBuilder {
+        private boolean epcisCompliant$set;
+        private boolean epcisCompliant$value;
+        private boolean validateCheckDigit$set;
+        private boolean validateCheckDigit$value;
+        private boolean gcpLength$set;
+        private Integer gcpLength$value;
+
+        ValidationContextBuilder() {
+        }
+
+        /**
+         * If true, enforce EPCIS‐compliance rules and validates GS1 AI against only EPCIS supported AI. Defaults to true.
+         * @return {@code this}.
+         */
+        public ValidationContext.ValidationContextBuilder epcisCompliant(boolean epcisCompliant) {
+            this.epcisCompliant$value = epcisCompliant;
+            epcisCompliant$set = true;
+            return this;
+        }
+
+        /**
+         * If true, run the GS1 check-digit validation along with normal validation. Defaults to true.
+         * @return {@code this}.
+         */
+        public ValidationContext.ValidationContextBuilder validateCheckDigit(boolean validateCheckDigit) {
+            this.validateCheckDigit$value = validateCheckDigit;
+            validateCheckDigit$set = true;
+            return this;
+        }
+
+        /**
+         * When present, validates for Digital-Link URI using this GCP length. Empty validates for URN mode.
+         * @return {@code this}.
+         */
+        public ValidationContext.ValidationContextBuilder gcpLength(Integer gcpLength) {
+            this.gcpLength$value = gcpLength;
+            gcpLength$set = true;
+            return this;
+        }
+
+        public ValidationContext build() {
+            boolean epcisCompliant$value = this.epcisCompliant$value;
+            if (!this.epcisCompliant$set) epcisCompliant$value = ValidationContext.$default$epcisCompliant();
+            boolean validateCheckDigit$value = this.validateCheckDigit$value;
+            if (!this.validateCheckDigit$set) validateCheckDigit$value = ValidationContext.$default$validateCheckDigit();
+            Integer gcpLength$value = this.gcpLength$value;
+            if (!this.gcpLength$set) gcpLength$value = ValidationContext.$default$gcpLength();
+            return new ValidationContext(epcisCompliant$value, validateCheckDigit$value, gcpLength$value);
+        }
+
+        @Override
+        public String toString() {
+            return "ValidationContext.ValidationContextBuilder(epcisCompliant$value=" + this.epcisCompliant$value + ", validateCheckDigit$value=" + this.validateCheckDigit$value + ", gcpLength$value=" + this.gcpLength$value + ")";
+        }
+    }
+
+    public static ValidationContext.ValidationContextBuilder builder() {
+        return new ValidationContext.ValidationContextBuilder();
+    }
 
     /**
      * If true, enforce EPCIS‐compliance rules and validates GS1 AI against only EPCIS supported AI. Defaults to true.
      */
-    @Builder.Default
-    boolean epcisCompliant = true;
+    public boolean isEpcisCompliant() {
+        return this.epcisCompliant;
+    }
 
     /**
      * If true, run the GS1 check-digit validation along with normal validation. Defaults to true.
      */
-    @Builder.Default
-    boolean validateCheckDigit = true;
+    public boolean isValidateCheckDigit() {
+        return this.validateCheckDigit;
+    }
 
     /**
      * When present, validates for Digital-Link URI using this GCP length. Empty validates for URN mode.
      */
-    @Builder.Default
-    Integer gcpLength = null;
+    public Integer getGcpLength() {
+        return this.gcpLength;
+    }
 
-    public static ValidationContext defaultContext() {
-        return ValidationContext.builder().build();
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (!(o instanceof ValidationContext)) return false;
+        ValidationContext other = (ValidationContext) o;
+        if (this.isEpcisCompliant() != other.isEpcisCompliant()) return false;
+        if (this.isValidateCheckDigit() != other.isValidateCheckDigit()) return false;
+        Object this$gcpLength = this.getGcpLength();
+        Object other$gcpLength = other.getGcpLength();
+        if (this$gcpLength == null ? other$gcpLength != null : !this$gcpLength.equals(other$gcpLength)) return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + (this.isEpcisCompliant() ? 79 : 97);
+        result = result * PRIME + (this.isValidateCheckDigit() ? 79 : 97);
+        Object $gcpLength = this.getGcpLength();
+        result = result * PRIME + ($gcpLength == null ? 43 : $gcpLength.hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ValidationContext(epcisCompliant=" + this.isEpcisCompliant() + ", validateCheckDigit=" + this.isValidateCheckDigit() + ", gcpLength=" + this.getGcpLength() + ")";
     }
 }

--- a/validator/core/src/main/java/io/openepcis/identifiers/validator/core/util/CheckDigitValidator.java
+++ b/validator/core/src/main/java/io/openepcis/identifiers/validator/core/util/CheckDigitValidator.java
@@ -1,43 +1,31 @@
 package io.openepcis.identifiers.validator.core.util;
 
 import io.openepcis.core.exception.ValidationException;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.krysalis.barcode4j.impl.upcean.UPCEANLogicImpl;
-
 import static io.openepcis.constants.ApplicationIdentifierConstants.*;
 
 /**
  * Utility for validating GS1 AI check digits in Digital Link URIs.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CheckDigitValidator {
-
     private static void validate(final String uri, final String aiPrefix, final int payloadLength, final String elementName) {
         final int idx = uri.indexOf(aiPrefix);
-
         // Check if the prefix is present in the URI
         if (idx < 0) {
             throw new ValidationException(elementName + " prefix not found in: " + uri);
         }
-
         final int start = idx + aiPrefix.length();
         final int end = start + payloadLength + 1;
-
         // Check if the segment is long enough
         if (end > uri.length()) {
             throw new ValidationException(elementName + " segment too short (" + payloadLength + "+1 digits) in: " + uri);
         }
-
-
         final String segment = uri.substring(start, end);
         final String data = segment.substring(0, payloadLength);
         final char checksumChar = UPCEANLogicImpl.calcChecksum(data);
-
         // compute the expected and actual check digit
         final int expected = Character.getNumericValue(checksumChar);
         final int actual = segment.charAt(payloadLength) - '0';
-
         if (expected != actual) {
             throw new ValidationException(String.format("%s has invalid check digit: expected %d but found %d in %s", elementName, expected, actual, uri));
         }
@@ -107,4 +95,6 @@ public class CheckDigitValidator {
         validate(uri, GCN_AI_URI_PREFIX, 12, "GCN");
     }
 
+    private CheckDigitValidator() {
+    }
 }

--- a/validator/core/src/test/java/io/openepcis/identifiers/tests/core/epcis/ApplicationIdentifierValidationTestUtil.java
+++ b/validator/core/src/test/java/io/openepcis/identifiers/tests/core/epcis/ApplicationIdentifierValidationTestUtil.java
@@ -15,15 +15,15 @@ import io.openepcis.digitallink.toolkit.GS1DigitalLinkNormalizer;
 import io.openepcis.digitallink.utils.DefaultGCPLengthProvider;
 import io.openepcis.identifiers.validator.ValidationContext;
 import io.openepcis.identifiers.validator.ValidatorFactory;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Assertions;
 
 /**
  * Utility for asserting validity or invalidity of GS1 application identifiers.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApplicationIdentifierValidationTestUtil {
+
+  private ApplicationIdentifierValidationTestUtil() {
+  }
 
     // Create a shared ValidatorFactory instance for all tests.
     private static final ValidatorFactory VALIDATOR_FACTORY = new ValidatorFactory(new GS1DigitalLinkNormalizer(), DefaultGCPLengthProvider.getInstance());


### PR DESCRIPTION
Part of moving the OpenEPCIS build to Java 25 / Quarkus 3.33 LTS.

**Heads-up for consumers:** the build target moves from Java 21 to 25, so artifacts produced from this branch cannot be consumed by projects still building on JDK 21.

Fast-forward — `main` is a strict ancestor of this branch, so there is nothing to merge and nothing that can conflict.

Lombok is removed in favour of explicit accessors, constructors and SLF4J loggers. A `javap -p` API diff per module was used to prove no accessor, constructor or builder method changed signature; the only differences anywhere were dead logger fields that were deleted rather than replaced.

Verified as part of the aggregate build: `-Pquarkus-rest` gives BUILD SUCCESS with 0 compile errors over 58 reactor entries.